### PR TITLE
make placeholder getter reactive and fix all resulting ts errors

### DIFF
--- a/packages/ramp-core/src/components/map/map-caption.vue
+++ b/packages/ramp-core/src/components/map/map-caption.vue
@@ -109,6 +109,7 @@
 </template>
 
 <script lang="ts">
+import { ComputedRef } from 'vue';
 import { Vue, Options } from 'vue-property-decorator';
 import { Get } from 'vuex-pathify';
 import { get } from '@/store/pathify-helper';
@@ -124,9 +125,9 @@ import NotificationsCaptionButtonV from '@/components/notification-center/captio
     }
 })
 export default class MapCaptionV extends Vue {
-    scale: ScaleBarProperties = get(MapCaptionStore.scale);
-    attribution: Attribution = get(MapCaptionStore.attribution);
-    cursorCoords: string = get(MapCaptionStore.cursorCoords);
+    scale: ComputedRef<ScaleBarProperties> = get(MapCaptionStore.scale);
+    attribution: ComputedRef<Attribution> = get(MapCaptionStore.attribution);
+    cursorCoords: ComputedRef<string> = get(MapCaptionStore.cursorCoords);
     // @Get(MapCaptionStore.scale) scale!: ScaleBarProperties;
     // @Get(MapCaptionStore.attribution) attribution!: Attribution;
     // @Get(MapCaptionStore.cursorCoords) cursorCoords!: string;

--- a/packages/ramp-core/src/components/notification-center/appbar-button.vue
+++ b/packages/ramp-core/src/components/notification-center/appbar-button.vue
@@ -23,13 +23,14 @@
 </template>
 
 <script lang="ts">
+import { ComputedRef } from 'vue';
 import { Vue, Options } from 'vue-property-decorator';
 import { Get } from 'vuex-pathify';
 import { get } from '@/store/pathify-helper';
 
 @Options({})
 export default class NotificationsAppbarButtonV extends Vue {
-    number: Number = get('notification/notificationNumber');
+    number: ComputedRef<Number> = get('notification/notificationNumber');
     // @Get('notification/notificationNumber') number!: Number;
 
     onClick() {

--- a/packages/ramp-core/src/components/notification-center/caption-button.vue
+++ b/packages/ramp-core/src/components/notification-center/caption-button.vue
@@ -61,6 +61,7 @@
 </template>
 
 <script lang="ts">
+import { ComputedRef } from 'vue';
 import { Vue, Options } from 'vue-property-decorator';
 import { Call, Get } from 'vuex-pathify';
 import { get } from '@/store/pathify-helper';
@@ -75,7 +76,7 @@ import NotificationListV from './notification-list.vue';
     }
 })
 export default class NotificationsCaptionButtonV extends Vue {
-    number: Number = get('notification/notificationNumber');
+    number: ComputedRef<Number> = get('notification/notificationNumber');
     // @Get('notification/notificationNumber') number!: Number;
     @Call('notification/clearAll') clearAll!: () => void;
 }

--- a/packages/ramp-core/src/components/notification-center/floating-button.vue
+++ b/packages/ramp-core/src/components/notification-center/floating-button.vue
@@ -27,12 +27,13 @@
 </template>
 
 <script lang="ts">
+import { ComputedRef } from 'vue';
 import { Vue } from 'vue-property-decorator';
 import { Get } from 'vuex-pathify';
 import { get } from '@/store/pathify-helper';
 
 export default class NotificationsFloatingButtonV extends Vue {
-    number: Number = get('notification/notificationNumber');
+    number: ComputedRef<Number> = get('notification/notificationNumber');
     // @Get('notification/notificationNumber') number!: Number;
 }
 </script>

--- a/packages/ramp-core/src/components/notification-center/notification-list.vue
+++ b/packages/ramp-core/src/components/notification-center/notification-list.vue
@@ -32,6 +32,7 @@
 </template>
 
 <script lang="ts">
+import { ComputedRef } from 'vue';
 import { Vue, Options } from 'vue-property-decorator';
 import { Get } from 'vuex-pathify';
 import { get } from '@/store/pathify-helper';
@@ -44,7 +45,9 @@ import NotificationItemV from './notification-item.vue';
     }
 })
 export default class NotificationListV extends Vue {
-    notificationStack: any[] = get('notification/notificationStack');
+    notificationStack: ComputedRef<any[]> = get(
+        'notification/notificationStack'
+    );
     // @Get('notification/notificationStack') notificationStack!: any[];
 }
 </script>

--- a/packages/ramp-core/src/components/panel-stack/panel-stack.vue
+++ b/packages/ramp-core/src/components/panel-stack/panel-stack.vue
@@ -15,6 +15,7 @@
 </template>
 
 <script lang="ts">
+import { ComputedRef } from 'vue';
 import { Vue, Options } from 'vue-property-decorator';
 import { Get, Sync } from 'vuex-pathify';
 import { get } from '@/store/pathify-helper';
@@ -38,7 +39,7 @@ declare class ResizeObserver {
     }
 })
 export default class PanelStackV extends Vue {
-    visible: (extraSmallScreen: boolean) => PanelInstance[] = get(
+    visible: ComputedRef<(extraSmallScreen: boolean) => PanelInstance[]> = get(
         'panel/getVisible'
     );
 

--- a/packages/ramp-core/src/components/shell.vue
+++ b/packages/ramp-core/src/components/shell.vue
@@ -18,6 +18,7 @@
 </template>
 
 <script lang="ts">
+import { ComputedRef } from 'vue';
 import { Vue, Options } from 'vue-property-decorator';
 
 import EsriMapV from '@/components/map/esri-map.vue';
@@ -38,7 +39,7 @@ import { FixtureInstance } from '@/api';
 })
 export default class Shell extends Vue {
     // TODO: this doesn't work
-    appbarFixture?: FixtureInstance = get(`fixture/items@appbar`);
+    appbarFixture?: ComputedRef<FixtureInstance> = get(`fixture/items@appbar`);
     // @Get(`fixture/items@appbar`) appbarFixture?: FixtureInstance;
 }
 </script>

--- a/packages/ramp-core/src/fixtures/appbar/appbar.vue
+++ b/packages/ramp-core/src/fixtures/appbar/appbar.vue
@@ -31,6 +31,7 @@
 </template>
 
 <script lang="ts">
+import { ComputedRef } from 'vue';
 import { Vue, Options } from 'vue-property-decorator';
 import { Get } from 'vuex-pathify';
 import { get } from '@/store/pathify-helper';
@@ -53,8 +54,8 @@ import NotificationsAppbarButtonV from '@/components/notification-center/appbar-
     }
 })
 export default class AppbarV extends Vue {
-    items: AppbarItemInstance[] = get('appbar/visible');
-    temporaryItems: AppbarItemInstance[] = get('appbar/temporary');
+    items: ComputedRef<AppbarItemInstance[]> = get('appbar/visible');
+    temporaryItems: ComputedRef<AppbarItemInstance[]> = get('appbar/temporary');
     // @Get('appbar/visible') items!: AppbarItemInstance[];
     // @Get('appbar/temporary') temporaryItems!: AppbarItemInstance[];
     overflow: boolean = false;

--- a/packages/ramp-core/src/fixtures/basemap/screen.vue
+++ b/packages/ramp-core/src/fixtures/basemap/screen.vue
@@ -72,6 +72,7 @@
 </template>
 
 <script lang="ts">
+import { ComputedRef } from 'vue';
 import { Vue, Options, Prop } from 'vue-property-decorator';
 import { Get } from 'vuex-pathify';
 import { get } from '@/store/pathify-helper';
@@ -88,9 +89,9 @@ import BasemapItemV from './item.vue';
 export default class BasemapScreenV extends Vue {
     @Prop() panel!: PanelInstance;
     // fetch basemap store properties/data
-    tileSchemas: Array<any> = get(BasemapStore.tileSchemas);
-    basemaps: Array<any> = get(BasemapStore.basemaps);
-    selectedBasemap: any = get(BasemapStore.selectedBasemap);
+    tileSchemas: ComputedRef<Array<any>> = get(BasemapStore.tileSchemas);
+    basemaps: ComputedRef<Array<any>> = get(BasemapStore.basemaps);
+    selectedBasemap: ComputedRef<any> = get(BasemapStore.selectedBasemap);
     // @Get(BasemapStore.tileSchemas) tileSchemas!: Array<any>;
     // @Get(BasemapStore.basemaps) basemaps!: Array<any>;
     // @Get(BasemapStore.selectedBasemap) selectedBasemap!: any;
@@ -101,7 +102,7 @@ export default class BasemapScreenV extends Vue {
 
     // filter out all the basemaps that match the current schema
     filterBasemaps(schemaId: string) {
-        return this.basemaps.filter(
+        return this.basemaps.value.filter(
             basemap => basemap.tileSchemaId === schemaId
         );
     }

--- a/packages/ramp-core/src/fixtures/details/item-screen.vue
+++ b/packages/ramp-core/src/fixtures/details/item-screen.vue
@@ -58,6 +58,7 @@
 </template>
 
 <script lang="ts">
+import { ComputedRef } from 'vue';
 import { Vue, Options, Prop } from 'vue-property-decorator';
 import { Get } from 'vuex-pathify';
 import { get } from '@/store/pathify-helper';
@@ -76,9 +77,9 @@ import HTMLDefaultV from './templates/html-default.vue';
     }
 })
 export default class DetailsItemScreenV extends Vue {
-    templateBindings: {
+    templateBindings: ComputedRef<{
         [id: string]: DetailsItemInstance;
-    } = get(DetailsStore.templates);
+    }> = get(DetailsStore.templates);
     // @Get(DetailsStore.templates) templateBindings!: {
     //     [id: string]: DetailsItemInstance;
     // };
@@ -94,11 +95,11 @@ export default class DetailsItemScreenV extends Vue {
     @Prop() isFeature!: boolean;
 
     // retrieve the identify payload from the store
-    payload: IdentifyResult[] = get(DetailsStore.payload);
+    payload: ComputedRef<IdentifyResult[]> = get(DetailsStore.payload);
     // @Get(DetailsStore.payload) payload!: IdentifyResult[];
-    getLayerByUid: (uid: string) => LayerInstance | undefined = get(
-        'layer/getLayerByUid'
-    );
+    getLayerByUid: ComputedRef<
+        (uid: string) => LayerInstance | undefined
+    > = get('layer/getLayerByUid');
     // @Get('layer/getLayerByUid') getLayerByUid!: (
     //     uid: string
     // ) => LayerInstance | undefined;
@@ -116,13 +117,13 @@ export default class DetailsItemScreenV extends Vue {
      * Returns the information for a single identify result, given the layer and item offsets.
      */
     get identifyItem() {
-        return this.payload[this.resultIndex].items[this.itemIndex];
+        return this.payload.value[this.resultIndex].items[this.itemIndex];
     }
 
     get itemName() {
-        const layerInfo = this.payload[this.resultIndex];
+        const layerInfo = this.payload.value[this.resultIndex];
         const uid = layerInfo.uid;
-        const layer: LayerInstance | undefined = this.getLayerByUid(uid);
+        const layer: LayerInstance | undefined = this.getLayerByUid.value(uid);
         const nameField = layer?.getNameField(uid);
         return nameField
             ? this.identifyItem.data[nameField]
@@ -130,9 +131,9 @@ export default class DetailsItemScreenV extends Vue {
     }
 
     fetchIcon() {
-        const layerInfo = this.payload[this.resultIndex];
+        const layerInfo = this.payload.value[this.resultIndex];
         const uid = layerInfo.uid;
-        const layer: LayerInstance | undefined = this.getLayerByUid(uid);
+        const layer: LayerInstance | undefined = this.getLayerByUid.value(uid);
         if (layer === undefined) {
             console.warn(
                 `could not find layer for uid ${uid} during icon lookup`
@@ -146,8 +147,8 @@ export default class DetailsItemScreenV extends Vue {
     }
 
     get detailsTemplate() {
-        const layerInfo = this.payload[this.resultIndex];
-        const layer: LayerInstance | undefined = this.getLayerByUid(
+        const layerInfo = this.payload.value[this.resultIndex];
+        const layer: LayerInstance | undefined = this.getLayerByUid.value(
             layerInfo.uid
         );
 
@@ -155,10 +156,10 @@ export default class DetailsItemScreenV extends Vue {
         // return its name.
         if (
             layer &&
-            this.templateBindings[layer.id] &&
-            this.templateBindings[layer.id].componentId
+            this.templateBindings.value[layer.id] &&
+            this.templateBindings.value[layer.id].componentId
         ) {
-            return this.templateBindings[layer.id].componentId;
+            return this.templateBindings.value[layer.id].componentId;
         }
 
         // If nothing is found, use a default template.
@@ -170,9 +171,9 @@ export default class DetailsItemScreenV extends Vue {
     }
 
     zoomToFeature() {
-        const layerInfo = this.payload[this.resultIndex];
+        const layerInfo = this.payload.value[this.resultIndex];
         const uid = layerInfo.uid;
-        const layer: LayerInstance | undefined = this.getLayerByUid(uid);
+        const layer: LayerInstance | undefined = this.getLayerByUid.value(uid);
 
         if (layer === undefined) {
             console.warn(

--- a/packages/ramp-core/src/fixtures/details/layers-screen.vue
+++ b/packages/ramp-core/src/fixtures/details/layers-screen.vue
@@ -33,6 +33,7 @@
 </template>
 
 <script lang="ts">
+import { ComputedRef } from 'vue';
 import { Vue, Prop } from 'vue-property-decorator';
 import { Get } from 'vuex-pathify';
 import { get } from '@/store/pathify-helper';
@@ -43,15 +44,15 @@ import { IdentifyResult } from '@/geo/api';
 
 export default class DetailsLayersScreenV extends Vue {
     @Prop() panel!: PanelInstance;
-    payload: IdentifyResult[] = get(DetailsStore.payload);
+    payload: ComputedRef<IdentifyResult[]> = get(DetailsStore.payload);
     // @Get(DetailsStore.payload) payload!: IdentifyResult[];
-    getLayerByUid: (uid: string) => LayerInstance | undefined = get(
-        'layer/getLayerByUid'
-    );
+    getLayerByUid: ComputedRef<
+        (uid: string) => LayerInstance | undefined
+    > = get('layer/getLayerByUid');
     // @Get('layer/getLayerByUid') getLayerByUid!: (
     //     uid: string
     // ) => LayerInstance | undefined;
-    layers: LayerInstance[] = get('layer/layers');
+    layers: ComputedRef<LayerInstance[]> = get('layer/layers');
     // @Get('layer/layers') layers!: LayerInstance[];
 
     /**
@@ -59,7 +60,8 @@ export default class DetailsLayersScreenV extends Vue {
      */
     openResult(index: number) {
         if (
-            this.getLayerByUid(this.payload[index].uid)!.layerType === 'ogcWms'
+            this.getLayerByUid.value(this.payload.value[index].uid)!
+                .layerType === 'ogcWms'
         ) {
             // skip results screen for wms layers
             this.panel.show({
@@ -75,10 +77,10 @@ export default class DetailsLayersScreenV extends Vue {
     }
 
     layerInfo(idx: number) {
-        const layerInfo = this.payload[idx];
+        const layerInfo = this.payload.value[idx];
 
         // Check to see if there is a custom template defined for the selected layer.
-        let item: LayerInstance | undefined = this.layers
+        let item: LayerInstance | undefined = this.layers.value
             .map(layer => {
                 let layerNode = layer.getLayerTree();
 
@@ -100,7 +102,9 @@ export default class DetailsLayersScreenV extends Vue {
      * Calculates the total number of results received by identify.
      */
     get payloadResults(): number {
-        return this.payload.map(r => r.items.length).reduce((a, b) => a + b, 0);
+        return this.payload.value
+            .map(r => r.items.length)
+            .reduce((a, b) => a + b, 0);
     }
 }
 </script>

--- a/packages/ramp-core/src/fixtures/details/result-screen.vue
+++ b/packages/ramp-core/src/fixtures/details/result-screen.vue
@@ -37,6 +37,7 @@
 </template>
 
 <script lang="ts">
+import { ComputedRef } from 'vue';
 import { Vue, Prop } from 'vue-property-decorator';
 import { Get } from 'vuex-pathify';
 import { get } from '@/store/pathify-helper';
@@ -49,11 +50,11 @@ export default class DetailsResultScreenV extends Vue {
     @Prop() panel!: PanelInstance;
     @Prop() resultIndex!: number;
 
-    payload: IdentifyResult[] = get(DetailsStore.payload);
+    payload: ComputedRef<IdentifyResult[]> = get(DetailsStore.payload);
     // @Get(DetailsStore.payload) payload!: IdentifyResult[];
-    getLayerByUid: (uid: string) => LayerInstance | undefined = get(
-        'layer/getLayerByUid'
-    );
+    getLayerByUid: ComputedRef<
+        (uid: string) => LayerInstance | undefined
+    > = get('layer/getLayerByUid');
     // @Get('layer/getLayerByUid') getLayerByUid!: (
     //     uid: string
     // ) => LayerInstance | undefined;
@@ -78,7 +79,7 @@ export default class DetailsResultScreenV extends Vue {
      */
     itemIcon(data: any, idx: number) {
         const uid = this.identifyResult.uid;
-        const layer: LayerInstance | undefined = this.getLayerByUid(uid);
+        const layer: LayerInstance | undefined = this.getLayerByUid.value(uid);
         if (layer === undefined) {
             console.warn(
                 `could not find layer for uid ${uid} during icon lookup`
@@ -100,16 +101,16 @@ export default class DetailsResultScreenV extends Vue {
      * Returns the identify information for the layer specified by resultIndex.
      */
     get identifyResult() {
-        return this.payload[this.resultIndex];
+        return this.payload.value[this.resultIndex];
     }
 
     /**
      * Returns the name field for the layer specified by resultIndex.
      */
     get nameField() {
-        const layerInfo = this.payload[this.resultIndex];
+        const layerInfo = this.payload.value[this.resultIndex];
         const uid = layerInfo?.uid;
-        const layer: LayerInstance | undefined = this.getLayerByUid(uid);
+        const layer: LayerInstance | undefined = this.getLayerByUid.value(uid);
         return layer?.getNameField(uid);
     }
 }

--- a/packages/ramp-core/src/fixtures/geosearch/screen.vue
+++ b/packages/ramp-core/src/fixtures/geosearch/screen.vue
@@ -96,6 +96,7 @@
 </template>
 
 <script lang="ts">
+import { ComputedRef } from 'vue';
 import { Vue, Options, Prop } from 'vue-property-decorator';
 import { Get } from 'vuex-pathify';
 import { get } from '@/store/pathify-helper';
@@ -119,9 +120,9 @@ import GeosearchLoadingBarV from './loading-bar.vue';
 export default class GeosearchScreenV extends Vue {
     @Prop() panel!: PanelInstance;
     // fetch store properties/data
-    searchVal: string = get(GeosearchStore.searchVal);
-    searchResults: Array<any> = get(GeosearchStore.searchResults);
-    loadingResults: boolean = get(GeosearchStore.loadingResults);
+    searchVal: ComputedRef<string> = get(GeosearchStore.searchVal);
+    searchResults: ComputedRef<Array<any>> = get(GeosearchStore.searchResults);
+    loadingResults: ComputedRef<boolean> = get(GeosearchStore.loadingResults);
     // @Get(GeosearchStore.searchVal) searchVal!: string;
     // @Get(GeosearchStore.searchResults) searchResults!: Array<any>;
     // @Get(GeosearchStore.loadingResults) loadingResults!: boolean;
@@ -140,7 +141,7 @@ export default class GeosearchScreenV extends Vue {
     highlightSearchTerm(name: string, province: any) {
         // wrap matched search term in results inside span with styling
         const highlightedResult = name.replace(
-            new RegExp(`${this.searchVal}`, 'gi'),
+            new RegExp(`${this.searchVal.value}`, 'gi'),
             match =>
                 '<span class="font-bold text-blue-600">' + match + '</span>'
         );

--- a/packages/ramp-core/src/fixtures/geosearch/search-bar.vue
+++ b/packages/ramp-core/src/fixtures/geosearch/search-bar.vue
@@ -11,6 +11,7 @@
 </template>
 
 <script lang="ts">
+import { ComputedRef } from 'vue';
 import { Vue } from 'vue-property-decorator';
 import { Get, Call } from 'vuex-pathify';
 import { get } from '@/store/pathify-helper';
@@ -20,7 +21,7 @@ import { debounce } from 'throttle-debounce';
 
 export default class GeosearchSearchBarV extends Vue {
     // fetch geosearch search value from store
-    searchVal: string = get(GeosearchStore.searchVal);
+    searchVal: ComputedRef<string> = get(GeosearchStore.searchVal);
     // @Get(GeosearchStore.searchVal) searchVal!: string;
 
     // import required geosearch actions

--- a/packages/ramp-core/src/fixtures/geosearch/top-filters.vue
+++ b/packages/ramp-core/src/fixtures/geosearch/top-filters.vue
@@ -50,6 +50,7 @@
 </template>
 
 <script lang="ts">
+import { ComputedRef } from 'vue';
 import { Vue } from 'vue-property-decorator';
 import { Get, Call } from 'vuex-pathify';
 import { get } from '@/store/pathify-helper';
@@ -58,9 +59,9 @@ import { GeosearchStore } from './store';
 
 export default class GeosearchTopFiltersV extends Vue {
     // fetch defined province/type filters + filter params from store
-    provinces: Array<any> = get(GeosearchStore.getProvinces);
-    types: Array<any> = get(GeosearchStore.getTypes);
-    queryParams: any = get(GeosearchStore.queryParams);
+    provinces: ComputedRef<Array<any>> = get(GeosearchStore.getProvinces);
+    types: ComputedRef<Array<any>> = get(GeosearchStore.getTypes);
+    queryParams: ComputedRef<any> = get(GeosearchStore.queryParams);
     // @Get(GeosearchStore.getProvinces) provinces!: Array<any>;
     // @Get(GeosearchStore.getTypes) types!: Array<any>;
     // @Get(GeosearchStore.queryParams) queryParams!: any;

--- a/packages/ramp-core/src/fixtures/grid/screen.vue
+++ b/packages/ramp-core/src/fixtures/grid/screen.vue
@@ -60,6 +60,7 @@
 </template>
 
 <script lang="ts">
+import { ComputedRef } from 'vue';
 import { Vue, Options, Prop } from 'vue-property-decorator';
 import { Get } from 'vuex-pathify';
 import { get } from '@/store/pathify-helper';
@@ -78,8 +79,8 @@ export default class GridScreenV extends Vue {
     @Prop() panel!: PanelInstance;
     @Prop() header!: String;
 
-    layers: LayerInstance[] = get(LayerStore.layers);
-    currentUid: any = get('grid/currentUid');
+    layers: ComputedRef<LayerInstance[]> = get(LayerStore.layers);
+    currentUid: ComputedRef<any> = get('grid/currentUid');
     // @Get(LayerStore.layers) layers!: LayerInstance[];
     // @Get('grid/currentUid') currentUid: any;
 

--- a/packages/ramp-core/src/fixtures/grid/table-component.vue
+++ b/packages/ramp-core/src/fixtures/grid/table-component.vue
@@ -75,6 +75,7 @@
 </template>
 
 <script lang="ts">
+import { ComputedRef } from 'vue';
 import { Vue, Options, Prop } from 'vue-property-decorator';
 import { Get, Sync } from 'vuex-pathify';
 import { get } from '@/store/pathify-helper';
@@ -116,9 +117,9 @@ const TEXT_TYPE: string = 'string';
 })
 export default class GridTableComponentV extends Vue {
     @Prop() layerUid!: string;
-    getLayerByUid: (uid: string) => LayerInstance | undefined = get(
-        'layer/getLayerByUid'
-    );
+    getLayerByUid: ComputedRef<
+        (uid: string) => LayerInstance | undefined
+    > = get('layer/getLayerByUid');
     // @Get('layer/getLayerByUid') getLayerByUid!: (
     //     uid: string
     // ) => LayerInstance | undefined;
@@ -160,7 +161,7 @@ export default class GridTableComponentV extends Vue {
             suppressColumnVirtualisation: true
         };
 
-        const fancyLayer: LayerInstance | undefined = this.getLayerByUid(
+        const fancyLayer: LayerInstance | undefined = this.getLayerByUid.value(
             this.layerUid
         );
         if (fancyLayer === undefined) {
@@ -492,9 +493,9 @@ export default class GridTableComponentV extends Vue {
                 isStatic: true,
                 maxWidth: 82,
                 cellRenderer: (cell: any) => {
-                    const layer: LayerInstance | undefined = this.getLayerByUid(
-                        this.layerUid
-                    );
+                    const layer:
+                        | LayerInstance
+                        | undefined = this.getLayerByUid.value(this.layerUid);
                     if (layer === undefined) return;
                     const iconContainer = document.createElement('span');
                     const oid = cell.data[this.oidField];

--- a/packages/ramp-core/src/fixtures/grid/templates/zoom-button-renderer.vue
+++ b/packages/ramp-core/src/fixtures/grid/templates/zoom-button-renderer.vue
@@ -22,15 +22,16 @@
 </template>
 
 <script lang="ts">
+import { ComputedRef } from 'vue';
 import { Vue } from 'vue-property-decorator';
 import { Get } from 'vuex-pathify';
 import { get } from '@/store/pathify-helper';
 import { LayerInstance } from '@/api/internal';
 
 export default class ZoomButtonRendererV extends Vue {
-    getLayerByUid: (uid: string) => LayerInstance | undefined = get(
-        'layer/getLayerByUid'
-    );
+    getLayerByUid: ComputedRef<
+        (uid: string) => LayerInstance | undefined
+    > = get('layer/getLayerByUid');
     // @Get('layer/getLayerByUid') getLayerByUid!: (
     //     uid: string
     // ) => LayerInstance | undefined;
@@ -56,7 +57,7 @@ export default class ZoomButtonRendererV extends Vue {
     }
 
     zoomToFeature() {
-        const layer: LayerInstance | undefined = this.getLayerByUid(
+        const layer: LayerInstance | undefined = this.getLayerByUid.value(
             this.params.uid
         );
         if (layer === undefined) return;

--- a/packages/ramp-core/src/fixtures/help/screen.vue
+++ b/packages/ramp-core/src/fixtures/help/screen.vue
@@ -20,6 +20,7 @@
 </template>
 
 <script lang="ts">
+import { ComputedRef } from 'vue';
 import { Vue, Options, Prop } from 'vue-property-decorator';
 import { Get } from 'vuex-pathify';
 import { get } from '@/store/pathify-helper';
@@ -39,7 +40,7 @@ import marked from 'marked';
 })
 export default class HelpScreenV extends Vue {
     @Prop() panel!: PanelInstance;
-    folderName: string = get(HelpStore.folderName);
+    folderName: ComputedRef<string> = get(HelpStore.folderName);
     // @Get(HelpStore.folderName) folderName!: string;
 
     helpSections: any = [];

--- a/packages/ramp-core/src/fixtures/legend/components/placeholder.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/placeholder.vue
@@ -37,6 +37,7 @@
 </template>
 
 <script lang="ts">
+import { ComputedRef } from 'vue';
 import { Vue, Options, Prop, Watch } from 'vue-property-decorator';
 import { Get } from 'vuex-pathify';
 import { get } from '@/store/pathify-helper';
@@ -58,7 +59,7 @@ import LegendSymbologyStackV from './symbology-stack.vue';
 })
 export default class LegendPlaceholderV extends Vue {
     @Prop() legendItem!: LegendEntry;
-    layers: LayerInstance[] = get(LayerStore.layers);
+    layers: ComputedRef<LayerInstance[]> = get(LayerStore.layers);
     // @Get(LayerStore.layers) layers!: LayerInstance[];
 
     layer: LayerInstance | undefined = undefined;
@@ -89,7 +90,7 @@ export default class LegendPlaceholderV extends Vue {
 
     mounted() {
         // in case layer is added while placeholder component is dead
-        this.layerAdded(this.layers, []);
+        this.layerAdded(this.layers.value, []);
     }
 }
 </script>

--- a/packages/ramp-core/src/fixtures/legend/screen.vue
+++ b/packages/ramp-core/src/fixtures/legend/screen.vue
@@ -23,6 +23,7 @@
 </template>
 
 <script lang="ts">
+import { ComputedRef } from 'vue';
 import { Vue, Options, Prop } from 'vue-property-decorator';
 import { Get } from 'vuex-pathify';
 import { get } from '@/store/pathify-helper';
@@ -42,7 +43,9 @@ import LegendComponentV from './components/component.vue';
 export default class LegendScreenV extends Vue {
     @Prop() panel!: PanelInstance;
     // fetch store properties/data
-    children: Array<LegendEntry | LegendGroup> = get(LegendStore.children);
+    children: ComputedRef<Array<LegendEntry | LegendGroup>> = get(
+        LegendStore.children
+    );
     // @Get(LegendStore.children) children!: Array<LegendEntry | LegendGroup>;
 
     get isPinned(): boolean {

--- a/packages/ramp-core/src/fixtures/mapnav/mapnav.vue
+++ b/packages/ramp-core/src/fixtures/mapnav/mapnav.vue
@@ -19,6 +19,7 @@
 </template>
 
 <script lang="ts">
+import { ComputedRef } from 'vue';
 import { Vue, Options } from 'vue-property-decorator';
 import { Get } from 'vuex-pathify';
 import { get } from '@/store/pathify-helper';
@@ -39,7 +40,7 @@ import MapnavButtonV from './button.vue';
     }
 })
 export default class MapNavV extends Vue {
-    visible: any[] = get('mapnav/visible');
+    visible: ComputedRef<any[]> = get('mapnav/visible');
     // @Get('mapnav/visible') visible!: any[];
 }
 </script>

--- a/packages/ramp-core/src/fixtures/northarrow/northarrow.vue
+++ b/packages/ramp-core/src/fixtures/northarrow/northarrow.vue
@@ -5,6 +5,7 @@
 </template>
 
 <script lang="ts">
+import { ComputedRef } from 'vue';
 import { Vue } from 'vue-property-decorator';
 import { Get } from 'vuex-pathify';
 import { get } from '@/store/pathify-helper';
@@ -15,8 +16,8 @@ import flag from './flag.json';
 import { debounce } from 'throttle-debounce';
 
 export default class NortharrowV extends Vue {
-    arrowIcon: string = get(NortharrowStore.arrowIcon);
-    poleIcon: string = get(NortharrowStore.poleIcon);
+    arrowIcon: ComputedRef<string> = get(NortharrowStore.arrowIcon);
+    poleIcon: ComputedRef<string> = get(NortharrowStore.poleIcon);
     // @Get(NortharrowStore.arrowIcon) arrowIcon!: string;
     // @Get(NortharrowStore.poleIcon) poleIcon!: string;
 
@@ -36,8 +37,8 @@ export default class NortharrowV extends Vue {
     poleMarkerAdded: boolean = false;
 
     mounted() {
-        if (this.arrowIcon) {
-            this.arrow = `<img width='25' src='${this.arrowIcon}'>`;
+        if (this.arrowIcon.value) {
+            this.arrow = `<img width='25' src='${this.arrowIcon.value}'>`;
         }
         // don't think this condition should be needed but sometimes errors at startup without it
         if (this.$iApi.geo.map.esriView?.ready) {
@@ -92,9 +93,9 @@ export default class NortharrowV extends Vue {
                     this.poleMarkerAdded = true;
                     // TODO update to use RAMP API Styles once Highlight Layer implements an api that accepts RAMP Graphics. Get rid of all ESRI stuff when that happens
                     let markerSymbol: any = flag;
-                    if (this.poleIcon) {
+                    if (this.poleIcon.value) {
                         // convert data uri to esri symbol json
-                        const [, contentType, , imageData] = this.poleIcon.split(/[:;,]/);
+                        const [, contentType, , imageData] = this.poleIcon.value.split(/[:;,]/);
                         markerSymbol = {
                             width: 16.5,
                             height: 16.5,

--- a/packages/ramp-core/src/fixtures/overviewmap/overviewmap.vue
+++ b/packages/ramp-core/src/fixtures/overviewmap/overviewmap.vue
@@ -51,6 +51,7 @@
 </template>
 
 <script lang="ts">
+import { ComputedRef } from 'vue';
 import { Vue } from 'vue-property-decorator';
 import { Get } from 'vuex-pathify';
 import { get } from '@/store/pathify-helper';
@@ -60,8 +61,8 @@ import { OverviewmapStore } from './store';
 import { defaultMercator, defaultLambert } from './default-config';
 
 export default class OverviewmapV extends Vue {
-    mapConfig: RampMapConfig = get(OverviewmapStore.mapConfig);
-    startMinimized: boolean = get(OverviewmapStore.startMinimized);
+    mapConfig: ComputedRef<RampMapConfig> = get(OverviewmapStore.mapConfig);
+    startMinimized: ComputedRef<boolean> = get(OverviewmapStore.startMinimized);
     // @Get(OverviewmapStore.mapConfig) mapConfig!: RampMapConfig;
     // @Get(OverviewmapStore.startMinimized) startMinimized!: boolean;
 
@@ -74,12 +75,12 @@ export default class OverviewmapV extends Vue {
     }
 
     mounted() {
-        const config = this.mapConfig || this.defaultConfig;
+        const config = this.mapConfig.value || this.defaultConfig;
         this.overviewMap.createMap(
             config,
             this.$el.querySelector('.overviewmap') as HTMLDivElement
         );
-        this.minimized = this.startMinimized;
+        this.minimized = this.startMinimized.value;
 
         this.$iApi.event.on(
             GlobalEvents.MAP_EXTENTCHANGE,

--- a/packages/ramp-core/src/fixtures/wizard/screen.vue
+++ b/packages/ramp-core/src/fixtures/wizard/screen.vue
@@ -174,6 +174,7 @@
 </template>
 
 <script lang="ts">
+import { ComputedRef } from 'vue';
 import { Vue, Options, Prop } from 'vue-property-decorator';
 import { Get, Sync, Call } from 'vuex-pathify';
 import { get } from '@/store/pathify-helper';
@@ -198,7 +199,7 @@ import StepperV from './stepper.vue';
 })
 export default class WizardScreenV extends Vue {
     @Prop() panel!: PanelInstance;
-    layerSource: LayerSource = get(WizardStore.layerSource);
+    layerSource: ComputedRef<LayerSource> = get(WizardStore.layerSource);
     // @Get(WizardStore.layerSource) layerSource!: LayerSource;
 
     @Sync(WizardStore.url) url!: string;
@@ -206,7 +207,7 @@ export default class WizardScreenV extends Vue {
     @Sync(WizardStore.typeSelection) typeSelection!: string;
     @Sync(WizardStore.layerInfo) layerInfo!: LayerInfo | undefined;
 
-    step: WizardStep = get(WizardStore.step);
+    step: ComputedRef<WizardStep> = get(WizardStore.step);
     // @Get(WizardStore.step) step!: WizardStep;
     @Call(WizardStore.goToStep) goToStep!: (step: WizardStep) => void;
 
@@ -269,8 +270,8 @@ export default class WizardScreenV extends Vue {
     // lifecycle hook captures errors from child components
     errorCaptured(err: Error, vm: Vue, info: string) {
         if (
-            this.step === WizardStep.FORMAT ||
-            this.step === WizardStep.CONFIGURE
+            this.step.value === WizardStep.FORMAT ||
+            this.step.value === WizardStep.CONFIGURE
         ) {
             this.setError(
                 'format',
@@ -293,18 +294,18 @@ export default class WizardScreenV extends Vue {
             }, 500);
         }
 
-        this.typeSelection = this.layerSource.guessFormatFromURL(this.url);
+        this.typeSelection = this.layerSource.value.guessFormatFromURL(this.url);
         this.goToStep(WizardStep.FORMAT);
     }
 
     async onSelectContinue() {
         this.layerInfo = this.isFileLayer
-            ? await this.layerSource.fetchFileInfo(
+            ? await this.layerSource.value.fetchFileInfo(
                   this.url,
                   this.typeSelection,
                   this.fileData
               )
-            : await this.layerSource.fetchServiceInfo(
+            : await this.layerSource.value.fetchServiceInfo(
                   this.url,
                   this.typeSelection
               );

--- a/packages/ramp-core/src/store/pathify-helper.js
+++ b/packages/ramp-core/src/store/pathify-helper.js
@@ -1,11 +1,15 @@
 /* temporary solution to get vuex-pathify functionality working until it is supported for Vue 3 */
 // TODO: convert to TS (there was some complex typing errors going on)
-import { computed } from 'vue';
+import { computed, ref, reactive } from 'vue';
 import { store } from '@/store/store';
 
 export function get(path) {
-    console.log("store: ", store, path, path in store.getters ? store.getters[path] : store.get(path));
-    return path in store.getters ? store.getters[path] : store.get(path);
+    const property =
+        path in store.getters
+            ? computed(() => store.getters[path])
+            : computed(() => store.get(path));
+    console.log("store: ", store, path, property);
+    return property;
 }
 
 // have not tested this yet (don't use) since @Sync appears to not be giving any console errors
@@ -23,13 +27,3 @@ export function sync(path) {
 export function call(path, payload) {
     return store.dispatch(path, payload);
 }
-
-// const PathifyHelper = context => {
-//     const { $store } = context.root;
-//     // const get = (path: string) => $store.get(path);
-//     const get = path => computed(() => $store.get(path));
-//     // const set = (path: string, value: any) => $store.set(path, value);
-//     const call = (action, payload) => $store.dispatch(action, payload);
-
-//     return { get, sync, call };
-// };


### PR DESCRIPTION
The map loads wahoo ✔
[Demo](http://ramp4-app.azureedge.net/demo/users/yileifeng/fix-reactivity-get/host/index.html)

I think there is a good chance that some of the `.value` calls are incorrect (some getters will not need unwrapping or something like that) and will result in additional errors when the panels/fixtures appear on the map, but they eliminate all the console and typescript errors which is good for now.