### PR TITLE
Vue3 legend fix

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -82,7 +82,7 @@ importers:
       vue-js-toggle-button: ^1.3.3
       vue-loader: next
       vue-property-decorator: ^10.0.0-rc.2
-      vue-slider-component: ^3.2.11
+      vue-slider-component: next
       vue-tippy: next
       vuepress: ~1.8.2
       vuex: ^4.0.0
@@ -123,7 +123,7 @@ importers:
       vue-js-toggle-button: 1.3.3_vue@3.1.5
       vue-loader: 16.4.1_d950f26881ceb539432b09680dd2e4b9
       vue-property-decorator: 10.0.0-rc.3_02f8eea4846df4e4acf82e1a0ada6ce8
-      vue-slider-component: 3.2.14_vue@3.1.5
+      vue-slider-component: 4.0.0-beta.4_02f8eea4846df4e4acf82e1a0ada6ce8
       vue-tippy: 6.0.0-alpha.31_vue@3.1.5
       vuex: 4.0.2_vue@3.1.5
       vuex-pathify: 1.4.5_vue@3.1.5+vuex@4.0.2
@@ -14496,13 +14496,14 @@ packages:
       vue-class-component: 8.0.0-rc.1_vue@3.1.5
     dev: false
 
-  /vue-property-decorator/8.5.1_vue@3.1.5:
-    resolution: {integrity: sha512-O6OUN2OMsYTGPvgFtXeBU3jPnX5ffQ9V4I1WfxFQ6dqz6cOUbR3Usou7kgFpfiXDvV7dJQSFcJ5yUPgOtPPm1Q==}
+  /vue-property-decorator/9.1.2_02f8eea4846df4e4acf82e1a0ada6ce8:
+    resolution: {integrity: sha512-xYA8MkZynPBGd/w5QFJ2d/NM0z/YeegMqYTphy7NJQXbZcuU6FC6AOdUAcy4SXP+YnkerC6AfH+ldg7PDk9ESQ==}
     peerDependencies:
       vue: '*'
+      vue-class-component: '*'
     dependencies:
       vue: 3.1.5
-      vue-class-component: 7.2.6_vue@3.1.5
+      vue-class-component: 8.0.0-rc.1_vue@3.1.5
     dev: false
 
   /vue-router/3.5.2:
@@ -14522,13 +14523,14 @@ packages:
       source-map: 0.5.6
     dev: true
 
-  /vue-slider-component/3.2.14_vue@3.1.5:
-    resolution: {integrity: sha512-h+1UJi4dtib6gt1GU/KUiHVGW9gqCNxCoqJK4iM9YgFeQu4AQu/wWg56RM5sOUhrbUA043+EqtvDfUtYARe+lQ==}
+  /vue-slider-component/4.0.0-beta.4_02f8eea4846df4e4acf82e1a0ada6ce8:
+    resolution: {integrity: sha512-ooKDv/FKLPR4N2O8BL3QvMoAvrSwSjj2+tx38dgvGRQaYYr0lpfH8vd175Hb1ayr6JRlnea7PYAeVtlg/jvTbQ==}
     dependencies:
       core-js: 3.15.2
-      vue-property-decorator: 8.5.1_vue@3.1.5
+      vue-property-decorator: 9.1.2_02f8eea4846df4e4acf82e1a0ada6ce8
     transitivePeerDependencies:
       - vue
+      - vue-class-component
     dev: false
 
   /vue-style-loader/4.1.3:

--- a/packages/ramp-core/package.json
+++ b/packages/ramp-core/package.json
@@ -44,7 +44,7 @@
         "vue-i18n": "^9.1.7",
         "vue-js-toggle-button": "^1.3.3",
         "vue-property-decorator": "^10.0.0-rc.2",
-        "vue-slider-component": "^3.2.11",
+        "vue-slider-component": "next",
         "vue-tippy": "next",
         "vuex": "^4.0.0",
         "vuex-pathify": "~1.4.1",

--- a/packages/ramp-core/src/api/panel.ts
+++ b/packages/ramp-core/src/api/panel.ts
@@ -1,5 +1,10 @@
 import { APIScope, GlobalEvents, PanelInstance } from './internal';
-import { PanelConfig, PanelConfigRoute, PanelMutation, PanelAction } from '@/store/modules/panel';
+import {
+    PanelConfig,
+    PanelConfigRoute,
+    PanelMutation,
+    PanelAction
+} from '@/store/modules/panel';
 
 import { I18nComponentOptions } from '@/lang';
 
@@ -13,7 +18,10 @@ export class PanelAPI extends APIScope {
      * @returns {PanelInstance}
      * @memberof PanelAPI
      */
-    register(value: PanelConfigPair, options?: PanelRegistrationOptions): PanelInstance;
+    register(
+        value: PanelConfigPair,
+        options?: PanelRegistrationOptions
+    ): PanelInstance;
     /**
      * Registers a set of provided panel objects and returns the resulting `PanelInstance` object set.
      * When the panel is registered, all its screens are added to the Vue as components right away.
@@ -23,12 +31,17 @@ export class PanelAPI extends APIScope {
      * @returns {PanelInstanceSet}
      * @memberof PanelAPI
      */
-    register(value: PanelConfigSet, options?: PanelRegistrationOptions): PanelInstanceSet;
+    register(
+        value: PanelConfigSet,
+        options?: PanelRegistrationOptions
+    ): PanelInstanceSet;
     register(
         value: PanelConfigPair | PanelConfigSet,
         options?: PanelRegistrationOptions
     ): PanelInstance | PanelInstanceSet {
-        const panelConfigs = isPanelConfigPair(value) ? { [value.id]: value.config } : value;
+        const panelConfigs = isPanelConfigPair(value)
+            ? { [value.id]: value.config }
+            : value;
 
         if (options) {
             const i18n = options.i18n || {};
@@ -49,13 +62,12 @@ export class PanelAPI extends APIScope {
 
         // TODO: check if the panel with the same id already exist and don't create a new one
         // create panel instances
-        const panels: PanelInstance[] = Object.entries(panelConfigs).reduce<PanelInstance[]>(
-            (map, [id, config]) => {
-                map.push(new PanelInstance(this.$iApi, id, config));
-                return map;
-            },
-            []
-        );
+        const panels: PanelInstance[] = Object.entries(panelConfigs).reduce<
+            PanelInstance[]
+        >((map, [id, config]) => {
+            map.push(new PanelInstance(this.$iApi, id, config));
+            return map;
+        }, []);
 
         // register all the panels with the store
         panels.forEach(panel =>
@@ -107,7 +119,9 @@ export class PanelAPI extends APIScope {
      * @memberof PanelAPI
      */
     open(value: string | PanelInstance | PanelInstancePath): PanelInstance {
-        let panel: PanelInstance, screen: string | undefined, props: object | undefined;
+        let panel: PanelInstance,
+            screen: string | undefined,
+            props: object | undefined;
 
         // figure out what is passed to the function and retrieve the panel object
         if (typeof value === 'string' || value instanceof PanelInstance) {
@@ -213,7 +227,10 @@ export class PanelAPI extends APIScope {
      * @returns {PanelInstance}
      * @memberof PanelAPI
      */
-    toggle(value: string | PanelInstance | PanelInstancePath, toggle?: boolean): PanelInstance {
+    toggle(
+        value: string | PanelInstance | PanelInstancePath,
+        toggle?: boolean
+    ): PanelInstance {
         let panel: PanelInstance;
 
         // figure out what is passed to the function, retrieve the panel object and make call to open or close function
@@ -309,7 +326,10 @@ export class PanelAPI extends APIScope {
      * @memberof PanelAPI
      */
     // TODO: implement panel route history
-    show(value: string | PanelInstance, route: PanelConfigRoute): PanelInstance {
+    show(
+        value: string | PanelInstance,
+        route: PanelConfigRoute
+    ): PanelInstance {
         const panel = this.get(value);
 
         // register all the panel screen components globally
@@ -355,8 +375,14 @@ export class PanelAPI extends APIScope {
  * @param {(PanelConfigPair | PanelConfigSet)} value
  * @returns {value is PanelConfigPair}
  */
-function isPanelConfigPair(value: PanelConfigPair | PanelConfigSet): value is PanelConfigPair {
-    return value.id !== undefined && typeof value.id === 'string' && value.config !== undefined;
+function isPanelConfigPair(
+    value: PanelConfigPair | PanelConfigSet
+): value is PanelConfigPair {
+    return (
+        value.id !== undefined &&
+        typeof value.id === 'string' &&
+        value.config !== undefined
+    );
 }
 
 /**

--- a/packages/ramp-core/src/components/map/esri-map.vue
+++ b/packages/ramp-core/src/components/map/esri-map.vue
@@ -158,7 +158,7 @@ export default class EsriMapV extends Vue {
 
     @Watch('mapConfig')
     onMapConfigChange(newValue: RampMapConfig, oldValue: RampMapConfig) {
-        console.log("new map config change: ", newValue, this.mapConfig);
+        console.log('new map config change: ', newValue, this.mapConfig);
         if (newValue === oldValue) {
             return;
         }

--- a/packages/ramp-core/src/components/panel-stack/panel-stack.vue
+++ b/packages/ramp-core/src/components/panel-stack/panel-stack.vue
@@ -15,10 +15,10 @@
 </template>
 
 <script lang="ts">
-import { ComputedRef } from 'vue';
 import { Vue, Options } from 'vue-property-decorator';
 import { Get, Sync } from 'vuex-pathify';
-import { get } from '@/store/pathify-helper';
+import { get, sync } from '@/store/pathify-helper';
+import { ComputedRef, WritableComputedRef } from 'vue';
 
 import anime from 'animejs';
 
@@ -46,7 +46,7 @@ export default class PanelStackV extends Vue {
     // @Get('panel/getVisible!') visible!: (
     //     extraSmallScreen: boolean
     // ) => PanelInstance[];
-    @Sync('panel/stackWidth') stackWidth!: number;
+    stackWidth: WritableComputedRef<number> = sync('panel/stackWidth');
 
     mounted(): void {
         // sync the `panel-stack` width into the store so that visible can get calculated

--- a/packages/ramp-core/src/fixtures/legend/api/legend.ts
+++ b/packages/ramp-core/src/fixtures/legend/api/legend.ts
@@ -36,6 +36,7 @@ export class LegendAPI extends FixtureInstance {
         const layers: LayerInstance[] | undefined = this.$vApp.$store.get(
             LayerStore.layers
         );
+
         let legendEntries: Array<LegendItem> = [];
         let stack: Array<any> = [];
         // initialize stack with all legend elements listed in config

--- a/packages/ramp-core/src/fixtures/legend/components/group.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/group.vue
@@ -63,14 +63,15 @@
 </template>
 
 <script lang="ts">
-import { Vue, Options, Prop } from 'vue-property-decorator';
+import { Vue, Options, Prop, Watch } from 'vue-property-decorator';
+import { defineAsyncComponent } from 'vue';
 
 import { LegendGroup, LegendTypes } from '../store/legend-defs';
 import LegendCheckboxV from './checkbox.vue';
 
 @Options({
     components: {
-        LegendComponent: () => import('./component.vue'),
+        LegendComponent: defineAsyncComponent(() => import('./component.vue')),
         checkbox: LegendCheckboxV
     }
 })

--- a/packages/ramp-core/src/fixtures/legend/components/placeholder.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/placeholder.vue
@@ -66,6 +66,10 @@ export default class LegendPlaceholderV extends Vue {
 
     @Watch('layers')
     layerAdded(newValue: LayerInstance[], oldValue: LayerInstance[]) {
+        if (newValue === undefined) {
+            return;
+        }
+
         this.layer = newValue.find(
             (layer: LayerInstance) => layer.id === this.legendItem.id
         );

--- a/packages/ramp-core/src/fixtures/legend/components/placeholder.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/placeholder.vue
@@ -94,7 +94,7 @@ export default class LegendPlaceholderV extends Vue {
 
     mounted() {
         // in case layer is added while placeholder component is dead
-        this.layerAdded(this.layers.value, []);
+        this.layerAdded(<LayerInstance[]>(<unknown>this.layers), []);
     }
 }
 </script>

--- a/packages/ramp-core/src/fixtures/legend/components/visibility-set.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/visibility-set.vue
@@ -65,6 +65,7 @@
 </template>
 
 <script lang="ts">
+import { defineAsyncComponent } from 'vue';
 import { Vue, Options, Prop } from 'vue-property-decorator';
 
 import { LegendSet, LegendTypes } from '../store/legend-defs';
@@ -72,7 +73,7 @@ import LegendCheckboxV from './checkbox.vue';
 
 @Options({
     components: {
-        LegendComponent: () => import('./component.vue'),
+        LegendComponent: defineAsyncComponent(() => import('./component.vue')),
         checkbox: LegendCheckboxV
     }
 })

--- a/packages/ramp-core/src/fixtures/legend/index.ts
+++ b/packages/ramp-core/src/fixtures/legend/index.ts
@@ -24,6 +24,7 @@ class LegendFixture extends LegendAPI {
                 i18n: { messages }
             }
         );
+
         // TODO: register legend panel
         this.$iApi.component('legend-appbar-button', LegendAppbarButtonV);
         this.$vApp.$store.registerModule('legend', legend());

--- a/packages/ramp-core/src/fixtures/legend/screen.vue
+++ b/packages/ramp-core/src/fixtures/legend/screen.vue
@@ -23,11 +23,11 @@
 </template>
 
 <script lang="ts">
-import { ComputedRef } from 'vue';
 import { Vue, Options, Prop } from 'vue-property-decorator';
 import { Get } from 'vuex-pathify';
 import { get } from '@/store/pathify-helper';
 import { PanelInstance } from '@/api';
+import { ComputedRef } from 'vue';
 
 import { LegendStore } from './store';
 import { LegendEntry, LegendGroup } from './store/legend-defs';

--- a/packages/ramp-core/src/geo/layer/common-layer.ts
+++ b/packages/ramp-core/src/geo/layer/common-layer.ts
@@ -30,6 +30,8 @@ import {
     TreeNode
 } from '@/geo/api';
 
+import { toRaw } from 'vue';
+
 export class CommonLayer extends LayerInstance {
     uid: string;
     id: string;
@@ -575,8 +577,9 @@ export class CommonLayer extends LayerInstance {
      */
     getVisibility(layerIdx: number | string | undefined = undefined): boolean {
         const fc = this.getFC(layerIdx);
+
         if (fc) {
-            return fc.getVisibility();
+            return toRaw(fc).getVisibility();
         } else {
             this.noLayerErr();
             return false;

--- a/packages/ramp-core/src/geo/layer/esriFeature/index.ts
+++ b/packages/ramp-core/src/geo/layer/esriFeature/index.ts
@@ -13,6 +13,7 @@ import {
 } from '@/geo/api';
 import { EsriFeatureLayer } from '@/geo/esri';
 import { FeatureFC } from './feature-fc';
+import { markRaw } from 'vue';
 
 class FeatureLayer extends AttribLayer {
     declare esriLayer: EsriFeatureLayer | undefined;
@@ -24,8 +25,8 @@ class FeatureLayer extends AttribLayer {
     }
 
     async initiate(): Promise<void> {
-        this.esriLayer = new EsriFeatureLayer(
-            this.makeEsriLayerConfig(this.origRampConfig)
+        this.esriLayer = markRaw(
+            new EsriFeatureLayer(this.makeEsriLayerConfig(this.origRampConfig))
         );
         await super.initiate();
     }

--- a/packages/ramp-core/src/geo/layer/esriImagery/index.ts
+++ b/packages/ramp-core/src/geo/layer/esriImagery/index.ts
@@ -3,6 +3,7 @@
 import { CommonFC, CommonLayer, InstanceAPI } from '@/api/internal';
 import { LayerType, RampLayerConfig, TreeNode } from '@/geo/api';
 import { EsriImageryLayer } from '@/geo/esri';
+import { markRaw } from 'vue';
 
 class ImageryLayer extends CommonLayer {
     declare esriLayer: EsriImageryLayer | undefined;
@@ -14,8 +15,8 @@ class ImageryLayer extends CommonLayer {
     }
 
     async initiate(): Promise<void> {
-        this.esriLayer = new EsriImageryLayer(
-            this.makeEsriLayerConfig(this.origRampConfig)
+        this.esriLayer = markRaw(
+            new EsriImageryLayer(this.makeEsriLayerConfig(this.origRampConfig))
         );
         await super.initiate();
     }

--- a/packages/ramp-core/src/geo/layer/esriMapImage/index.ts
+++ b/packages/ramp-core/src/geo/layer/esriMapImage/index.ts
@@ -453,7 +453,7 @@ class MapImageLayer extends AttribLayer {
      */
     getVisibility(layerIdx: number | string | undefined = undefined): boolean {
         const fc = this.getFC(layerIdx, true);
-        console.log('GETVIS', fc, this.esriLayer);
+
         if (!fc) {
             return !!this.esriLayer?.visible;
         } else {

--- a/packages/ramp-core/src/geo/layer/esriMapImage/index.ts
+++ b/packages/ramp-core/src/geo/layer/esriMapImage/index.ts
@@ -15,6 +15,7 @@ import {
 } from '@/geo/api';
 import { EsriMapImageLayer, EsriRequest } from '@/geo/esri';
 import { MapImageFC } from './map-image-fc';
+import { markRaw } from 'vue';
 
 // Formerly known as DynamicLayer
 class MapImageLayer extends AttribLayer {
@@ -30,8 +31,8 @@ class MapImageLayer extends AttribLayer {
     }
 
     async initiate(): Promise<void> {
-        this.esriLayer = new EsriMapImageLayer(
-            this.makeEsriLayerConfig(this.origRampConfig)
+        this.esriLayer = markRaw(
+            new EsriMapImageLayer(this.makeEsriLayerConfig(this.origRampConfig))
         );
         await super.initiate();
     }
@@ -452,6 +453,7 @@ class MapImageLayer extends AttribLayer {
      */
     getVisibility(layerIdx: number | string | undefined = undefined): boolean {
         const fc = this.getFC(layerIdx, true);
+        console.log('GETVIS', fc, this.esriLayer);
         if (!fc) {
             return !!this.esriLayer?.visible;
         } else {

--- a/packages/ramp-core/src/geo/layer/esriMapImage/map-image-fc.ts
+++ b/packages/ramp-core/src/geo/layer/esriMapImage/map-image-fc.ts
@@ -3,6 +3,7 @@
 import { AttribFC } from '@/api/internal';
 import { DataFormat } from '@/geo/api';
 import MapImageLayer from './index';
+import { markRaw } from 'vue';
 
 export class MapImageFC extends AttribFC {
     // @ts-ignore
@@ -22,9 +23,11 @@ export class MapImageFC extends AttribFC {
         }
 
         // TODO not found check?
-        this.esriSubLayer = parent.esriLayer.allSublayers.find(s => {
-            return s.id === layerIdx;
-        });
+        this.esriSubLayer = markRaw(
+            parent.esriLayer.allSublayers.find(s => {
+                return s.id === layerIdx;
+            })
+        );
     }
 
     /**

--- a/packages/ramp-core/src/geo/layer/esriTile/index.ts
+++ b/packages/ramp-core/src/geo/layer/esriTile/index.ts
@@ -3,6 +3,7 @@
 import { CommonFC, CommonLayer, InstanceAPI } from '@/api/internal';
 import { LayerType, RampLayerConfig, TreeNode } from '@/geo/api';
 import { EsriTileLayer } from '@/geo/esri';
+import { markRaw } from 'vue';
 
 class TileLayer extends CommonLayer {
     declare esriLayer: EsriTileLayer | undefined;
@@ -14,8 +15,8 @@ class TileLayer extends CommonLayer {
     }
 
     async initiate(): Promise<void> {
-        this.esriLayer = new EsriTileLayer(
-            this.makeEsriLayerConfig(this.origRampConfig)
+        this.esriLayer = markRaw(
+            new EsriTileLayer(this.makeEsriLayerConfig(this.origRampConfig))
         );
         await super.initiate();
     }

--- a/packages/ramp-core/src/geo/layer/file-fc.ts
+++ b/packages/ramp-core/src/geo/layer/file-fc.ts
@@ -15,6 +15,7 @@ import {
     QueryFeaturesParams
 } from '@/geo/api';
 import { EsriFeatureFilter } from '@/geo/esri';
+import { toRaw } from 'vue';
 
 export class FileFC extends AttribFC {
     // @ts-ignore
@@ -179,7 +180,7 @@ export class FileFC extends AttribFC {
 
         // NOTE this can be expanded to have spatial filters as well. if we head to that,
         //      will will need to ensure any spatial elements get included in the new FeatureFilter
-        this.parentLayer.esriView.filter = new EsriFeatureFilter({
+        toRaw(this.parentLayer.esriView).filter = new EsriFeatureFilter({
             where: sql
         });
     }

--- a/packages/ramp-core/src/geo/layer/file-layer.ts
+++ b/packages/ramp-core/src/geo/layer/file-layer.ts
@@ -17,6 +17,7 @@ import {
     TreeNode
 } from '@/geo/api';
 import { EsriFeatureLayer, EsriField } from '@/geo/esri';
+import { markRaw } from 'vue';
 
 // util function to manage trickery. file layer can have field names that are bad keys.
 // our file loader will have corrected them, but ramp layer config .nameField and .tooltipField may
@@ -88,8 +89,8 @@ export class FileLayer extends AttribLayer {
             opts
         );
 
-        this.esriLayer = new EsriFeatureLayer(
-            this.makeEsriLayerConfig(this.origRampConfig)
+        this.esriLayer = markRaw(
+            new EsriFeatureLayer(this.makeEsriLayerConfig(this.origRampConfig))
         );
 
         this.esriJson = undefined;

--- a/packages/ramp-core/src/geo/layer/highlight/index.ts
+++ b/packages/ramp-core/src/geo/layer/highlight/index.ts
@@ -16,6 +16,7 @@ import {
     EsriGraphicsLayer,
     EsriPictureMarkerSymbol
 } from '@/geo/esri';
+import { markRaw } from 'vue';
 
 /**
  * Generate a graphic layer to handle feature highlighting.
@@ -61,10 +62,12 @@ export default class HighlightLayer extends CommonLayer {
     async initiate(): Promise<void> {
         // TODO determine if we are setting a layer type for highlight layers.
 
-        this.esriLayer = new EsriGraphicsLayer({
-            id: this.origRampConfig.id,
-            visible: true
-        });
+        this.esriLayer = markRaw(
+            new EsriGraphicsLayer({
+                id: this.origRampConfig.id,
+                visible: true
+            })
+        );
         await super.initiate();
     }
 

--- a/packages/ramp-core/src/geo/layer/ogcWms/index.ts
+++ b/packages/ramp-core/src/geo/layer/ogcWms/index.ts
@@ -13,6 +13,7 @@ import {
 } from '@/geo/api';
 import { EsriRequest, EsriWMSLayer, EsriWMSSublayer } from '@/geo/esri';
 import { WmsFC } from './wms-fc';
+import { markRaw } from 'vue';
 
 export default class WmsLayer extends CommonLayer {
     declare esriLayer: EsriWMSLayer | undefined;
@@ -28,8 +29,8 @@ export default class WmsLayer extends CommonLayer {
     }
 
     async initiate(): Promise<void> {
-        this.esriLayer = new EsriWMSLayer(
-            this.makeEsriLayerConfig(this.origRampConfig)
+        this.esriLayer = markRaw(
+            new EsriWMSLayer(this.makeEsriLayerConfig(this.origRampConfig))
         );
         await super.initiate();
     }

--- a/packages/ramp-core/src/store/pathify-helper.js
+++ b/packages/ramp-core/src/store/pathify-helper.js
@@ -8,7 +8,7 @@ export function get(path) {
         path in store.getters
             ? computed(() => store.getters[path])
             : computed(() => store.get(path));
-    console.log("store: ", store, path, property);
+    console.log('store: ', store, path, property);
     return property;
 }
 


### PR DESCRIPTION
🤮 

Changes:
- panels will display on the map now
- legend fixture now works properly
- map won't freeze when you click on a feature on the map. Details panel still doesn't open for some reason.

What I'm unsure about:
- I've had to wrap all of the ESRI layers with `markRaw` so Vue would not make them reactive. This may cause problems in other parts of the app, not able to test that at the moment.
- Some other objects were wrapped with `toRaw` (i.e., `toRaw(this.parentLayer.esriView).filter`, which pretty ugly). We may be able to remove these and wrap the esriView object with `markRaw` on the parent.
- These changes were necessary in order to prevent a conflict between the new Vue reactivity and the ArcGIS API. See a discussion on a related issue [here](https://stackoverflow.com/questions/65693108/threejs-component-working-in-vuejs-2-but-not-3)

[Demo Link](http://ramp4-app.azureedge.net/demo/users/RyanCoulsonCA/vue3-reactive-fix/host/index.html)