### PR TITLE
Creation of Dynamic Components

### DIFF
--- a/packages/ramp-core/src/api/fixture.ts
+++ b/packages/ramp-core/src/api/fixture.ts
@@ -269,14 +269,23 @@ export class FixtureInstance extends APIScope implements FixtureBase {
      * A helper function to create a "subclass" of the base Vue constructor
      *
      * @param {VueConstructor<Vue>} vueComponent
+     * @param {any} components
+     * @param {any} directives
      * @param {ComponentOptions<Vue>} [options={}]
      * @param {boolean} [mount=true]
      * @returns {Vue}
      * @memberof FixtureInstance
      */
-    extend(vueComponent: Record<string, any>, options: ComponentOptions = {}) {
+    extend(
+        vueComponent: Record<string, any>,
+        components?: any,
+        directives?: any,
+        options: ComponentOptions = {}
+    ) {
         const component = defineComponent({
             extends: vueComponent,
+            components: components,
+            directives: directives,
             data() {
                 return {
                     ...options,

--- a/packages/ramp-core/src/api/fixture.ts
+++ b/packages/ramp-core/src/api/fixture.ts
@@ -1,4 +1,4 @@
-import Vue, { ComponentOptions } from 'vue';
+import Vue, { ComponentOptions, createApp, defineComponent } from 'vue';
 
 import { APIScope, GlobalEvents, InstanceAPI } from './internal';
 import {
@@ -6,7 +6,6 @@ import {
     FixtureMutation,
     FixtureBaseSet
 } from '@/store/modules/fixture';
-import { i18n } from '@/lang';
 
 // TODO: implement the same `internal.ts` pattern in store, so can import from a single place;
 
@@ -269,29 +268,28 @@ export class FixtureInstance extends APIScope implements FixtureBase {
     /**
      * A helper function to create a "subclass" of the base Vue constructor
      *
-     * @param {VueConstructor<Vue>} vueConstructor
+     * @param {VueConstructor<Vue>} vueComponent
      * @param {ComponentOptions<Vue>} [options={}]
      * @param {boolean} [mount=true]
      * @returns {Vue}
      * @memberof FixtureInstance
      */
-    extend(
-        vueConstructor: Record<string, any>,
-        options: ComponentOptions<any> = {}
-    ): any {
-        const component = Object.assign(vueConstructor, {
-            iApi: this.$iApi,
-            ...options,
-            propsData: {
-                ...options.propsData,
-                fixture: this
-            },
-            i18n
+    extend(vueComponent: Record<string, any>, options: ComponentOptions = {}) {
+        const component = defineComponent({
+            extends: vueComponent,
+            data() {
+                return {
+                    ...options,
+                    propsData: {
+                        ...options.propsData,
+                        fixture: this
+                    }
+                };
+            }
         });
 
-        component.$mount();
-
-        return component;
+        const componentApp = createApp(component);
+        return componentApp;
     }
 
     added?(): void;

--- a/packages/ramp-core/src/api/instance.ts
+++ b/packages/ramp-core/src/api/instance.ts
@@ -10,14 +10,14 @@ import screenfull from 'screenfull';
 import mixin from './mixin';
 
 import App from '@/app.vue';
-import { store } from '@/store';
+import { store, storeType } from '@/store';
 import { ConfigStore } from '@/store/modules/config';
-import VueFormulate from '@braid/vue-formulate';
 
 //@ts-ignore
 import VueTippy, { TippyComponent, tippy } from 'vue-tippy';
 import { FocusList, FocusItem } from '@/directives/focus-list';
 import { Truncate } from '@/directives/truncate/truncate';
+import { VueI18n } from 'vue-i18n';
 
 import {
     EventAPI,
@@ -35,6 +35,13 @@ import BackV from '@/components/panel-stack/controls/back.vue';
 import PanelOptionsMenuV from '@/components/panel-stack/controls/panel-options-menu.vue';
 import DropdownMenuV from '@/components/controls/dropdown-menu.vue';
 import MinimizeV from '@/components/controls/dropdown-menu.vue';
+
+import FullscreenNavV from '@/fixtures/mapnav/buttons/fullscreen-nav.vue';
+import HomeNavV from '@/fixtures/mapnav/buttons/home-nav.vue';
+import MapnavButtonV from '@/fixtures/mapnav/button.vue';
+
+import DividerV from '@/fixtures/appbar/divider.vue';
+import AppbarButtonV from '@/fixtures/appbar/button.vue';
 
 interface RampOptions {
     loadDefaultFixtures?: boolean;
@@ -281,9 +288,7 @@ export class InstanceAPI {
 function createApp(element: HTMLElement, iApi: InstanceAPI) {
     // passing the `iApi` reference to the root Vue component will propagate it to all the child component in this instance of R4MP Vue application
     // if several R4MP apps are created, each will contain a reference of its own API instance
-    const vueElement = createRampApp(App, {
-        iApi
-    })
+    const vueElement = createRampApp(App)
         .use(store)
         .use(i18n)
         //.use(VueFormulate)
@@ -306,6 +311,14 @@ function createApp(element: HTMLElement, iApi: InstanceAPI) {
     vueElement.component('panel-options-menu', PanelOptionsMenuV);
     vueElement.component('dropdown-menu', DropdownMenuV);
     vueElement.component('minimize', MinimizeV);
+
+    // ported from mapnav.vue
+    vueElement.component('fullscreen-nav-button', FullscreenNavV);
+    vueElement.component('home-nav-button', HomeNavV);
+    vueElement.component('mapnav-button', MapnavButtonV);
+
+    vueElement.component('divider', DividerV);
+    vueElement.component('appbar-button', AppbarButtonV);
 
     vueElement.config.globalProperties.$store = store;
     vueElement.config.globalProperties.$iApi = iApi;

--- a/packages/ramp-core/src/components/controls/dropdown-menu.vue
+++ b/packages/ramp-core/src/components/controls/dropdown-menu.vue
@@ -1,10 +1,16 @@
 <template>
     <div>
-        <button
+        <!-- <button
             class="text-gray-500 hover:text-black dropdown-button"
             @click="open = !open"
             :content="tooltip"
             v-tippy="{ placement: tooltipPlacement }"
+            ref="dropdown-trigger"
+        > -->
+        <button
+            class="text-gray-500 hover:text-black dropdown-button"
+            @click="open = !open"
+            :content="tooltip"
             ref="dropdown-trigger"
         >
             <slot name="header"></slot>

--- a/packages/ramp-core/src/components/notification-center/appbar-button.vue
+++ b/packages/ramp-core/src/components/notification-center/appbar-button.vue
@@ -1,7 +1,7 @@
 <template>
     <appbar-button
         :onClickFunction="onClick"
-        :tooltip="$t('notifications.title')"
+        :tooltip="t('notifications.title')"
         class="notification-button"
     >
         <!-- https://fonts.google.com/icons?selected=Material%20Icons%3Anotifications -->
@@ -23,20 +23,33 @@
 </template>
 
 <script lang="ts">
-import { ComputedRef } from 'vue';
+import { ComputedRef, defineComponent } from 'vue';
 import { Vue, Options } from 'vue-property-decorator';
 import { Get } from 'vuex-pathify';
 import { get } from '@/store/pathify-helper';
+// this should not need to be imported
+import AppbarButtonV from '@/fixtures/appbar/button.vue';
 
-@Options({})
-export default class NotificationsAppbarButtonV extends Vue {
-    number: ComputedRef<Number> = get('notification/notificationNumber');
-    // @Get('notification/notificationNumber') number!: Number;
+export default defineComponent({
+    name: 'NotificationsAppbarButtonV',
+    props: ['t', 'iApi'],
+    components: {
+        'appbar-button': AppbarButtonV
+    },
 
-    onClick() {
-        this.$iApi.panel.toggle('notifications-panel');
+    data() {
+        return {
+            number: get('notification/notificationNumber')
+            // @Get('notification/notificationNumber') number!: Number;
+        };
+    },
+
+    methods: {
+        onClick() {
+            this.iApi.panel.toggle('notifications-panel');
+        }
     }
-}
+});
 </script>
 
 <style lang="scss" scoped>

--- a/packages/ramp-core/src/fixtures/appbar/appbar.vue
+++ b/packages/ramp-core/src/fixtures/appbar/appbar.vue
@@ -11,6 +11,8 @@
             :class="{ 'h-48': item.id !== 'divider' }"
             :options="item.options"
             :id="item.id"
+            :t="i18n.t"
+            :iApi="iApi"
         ></component>
         <divider class="appbar-item"></divider>
         <component
@@ -22,94 +24,125 @@
             :id="item.id"
         >
         </component>
-        <more-button id="more" v-show="overflow"></more-button>
+        <more-button id="more" v-show="overflow" :t="i18n.t"></more-button>
         <notifications-appbar-button
             class="appbar-item bottom-48 h-48 sm:hidden"
+            :t="i18n.t"
+            :iApi="iApi"
         ></notifications-appbar-button>
-        <nav-button id="nav"></nav-button>
+        <nav-button id="nav" :t="i18n.t" :iApi="iApi"></nav-button>
     </div>
 </template>
 
 <script lang="ts">
-import { ComputedRef } from 'vue';
+import { ComputedRef, defineComponent } from 'vue';
 import { Vue, Options } from 'vue-property-decorator';
 import { Get } from 'vuex-pathify';
 import { get } from '@/store/pathify-helper';
 
 import { AppbarItemInstance } from './store';
 
-import AppbarButtonV from './button.vue';
-import DividerV from './divider.vue';
 import MoreAppbarButtonV from './more-button.vue';
 import NavAppbarButtonV from './nav-button.vue';
 import NotificationsAppbarButtonV from '@/components/notification-center/appbar-button.vue';
+// maybe these should not be needed?
+import LegendAppbarButtonV from '@/fixtures/legend/appbar-button.vue';
+import BasemapAppbarButtonV from '@/fixtures/basemap/appbar-button.vue';
+import GeosearchAppbarButtonV from '@/fixtures/geosearch/appbar-button.vue';
 
-@Options({
+// @Options({
+//     components: {
+//         'more-button': MoreAppbarButtonV,
+//         'nav-button': NavAppbarButtonV,
+//         'notifications-appbar-button': NotificationsAppbarButtonV
+//     }
+// })
+
+export default defineComponent({
+    name: 'AppbarV',
     components: {
         'more-button': MoreAppbarButtonV,
         'nav-button': NavAppbarButtonV,
         'notifications-appbar-button': NotificationsAppbarButtonV,
-        divider: DividerV,
-        'appbar-button': AppbarButtonV
+        legend: LegendAppbarButtonV,
+        basemap: BasemapAppbarButtonV,
+        geosearch: GeosearchAppbarButtonV
+    },
+
+    data() {
+        return {
+            items: get('appbar/visible'),
+            temporaryItems: get('appbar/temporary'),
+            // @Get('appbar/visible') items!: AppbarItemInstance[];
+            // @Get('appbar/temporary') temporaryItems!: AppbarItemInstance[];
+            overflow: false
+        };
+    },
+
+    created() {
+        console.log('appbar instantiation: ', this);
     }
-})
-export default class AppbarV extends Vue {
-    items: ComputedRef<AppbarItemInstance[]> = get('appbar/visible');
-    temporaryItems: ComputedRef<AppbarItemInstance[]> = get('appbar/temporary');
-    // @Get('appbar/visible') items!: AppbarItemInstance[];
-    // @Get('appbar/temporary') temporaryItems!: AppbarItemInstance[];
-    overflow: boolean = false;
 
-    updated() {
-        let children: Element[] = [...this.$el.children];
-        let bound: number | undefined = this.$el.lastElementChild?.getBoundingClientRect().top;
-        let dropdown: Element | null = document.getElementById('dropdown');
+    // TODO: update this after (issue with getBoundingClientRect)
+    // updated() {
+    //     let children: Element[] = [...this.$el.childNodes];
+    //     console.log('appbar updated: ', this);
+    //     let bound:
+    //         | number
+    //         | undefined = this.$el.lastChild?.getBoundingClientRect().top;
+    //     let dropdown: Element | null = document.getElementById('dropdown');
 
-        // check positions of appbar buttons
-        for (let i = children.length - 3; i >= 0; i--) {
-            if (
-                bound &&
-                dropdown &&
-                (children[i].getBoundingClientRect().bottom >= bound ||
-                    (this.overflow && children[i].getBoundingClientRect().bottom + 48 >= bound))
-            ) {
-                children[i].classList.remove('hover:text-white', 'text-gray-400');
-                children[i].classList.add('text-black', 'hover:bg-gray-100');
+    //     // check positions of appbar buttons
+    //     for (let i = children.length - 3; i >= 0; i--) {
+    //         if (
+    //             bound &&
+    //             dropdown &&
+    //             (children[i].getBoundingClientRect().bottom >= bound ||
+    //                 (this.overflow &&
+    //                     children[i].getBoundingClientRect().bottom + 48 >=
+    //                         bound))
+    //         ) {
+    //             children[i].classList.remove(
+    //                 'hover:text-white',
+    //                 'text-gray-400'
+    //             );
+    //             children[i].classList.add('text-black', 'hover:bg-gray-100');
 
-                this.$el.removeChild(children[i]);
-                dropdown.appendChild(children[i]);
-                if (!this.overflow) this.overflow = true;
-            } else {
-                break;
-            }
-        }
+    //             this.$el.removeChild(children[i]);
+    //             dropdown.appendChild(children[i]);
+    //             if (!this.overflow) this.overflow = true;
+    //         } else {
+    //             break;
+    //         }
+    //     }
 
-        // check position of more button
-        let more: Element | null = document.getElementById('more');
-        if (
-            this.overflow &&
-            bound &&
-            more &&
-            dropdown &&
-            more.getBoundingClientRect().bottom !== 0 &&
-            (more.getBoundingClientRect().bottom <= bound - 48 || dropdown.childElementCount == 1)
-        ) {
-            while (
-                more.getBoundingClientRect().bottom <= bound - 48 ||
-                dropdown.childElementCount == 1
-            ) {
-                //@ts-ignore
-                let item: Element = dropdown.firstElementChild;
-                item.classList.remove('text-black', 'hover:bg-gray-100');
-                item.classList.add('text-gray-400', 'hover:text-white');
+    //     // check position of more button
+    //     let more: Element | null = document.getElementById('more');
+    //     if (
+    //         this.overflow &&
+    //         bound &&
+    //         more &&
+    //         dropdown &&
+    //         more.getBoundingClientRect().bottom !== 0 &&
+    //         (more.getBoundingClientRect().bottom <= bound - 48 ||
+    //             dropdown.childElementCount == 1)
+    //     ) {
+    //         while (
+    //             more.getBoundingClientRect().bottom <= bound - 48 ||
+    //             dropdown.childElementCount == 1
+    //         ) {
+    //             //@ts-ignore
+    //             let item: Element = dropdown.firstElementChild;
+    //             item.classList.remove('text-black', 'hover:bg-gray-100');
+    //             item.classList.add('text-gray-400', 'hover:text-white');
 
-                dropdown.removeChild(item);
-                this.$el.insertBefore(item, more);
-            }
-            if (dropdown.childElementCount == 0) this.overflow = false;
-        }
-    }
-}
+    //             dropdown.removeChild(item);
+    //             this.$el.insertBefore(item, more);
+    //         }
+    //         if (dropdown.childElementCount == 0) this.overflow = false;
+    //     }
+    // }
+});
 </script>
 
 <style lang="scss">

--- a/packages/ramp-core/src/fixtures/appbar/button.vue
+++ b/packages/ramp-core/src/fixtures/appbar/button.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="relative" tabindex="-1">
-        <button
+        <!-- <button
             class="py-6 w-full h-full focus:outline-none"
             @click="
                 () => {
@@ -11,6 +11,16 @@
             v-focus-item
             :content="tooltip"
             v-tippy="{ placement: 'right' }"
+        > -->
+        <button
+            class="py-6 w-full h-full focus:outline-none"
+            @click="
+                () => {
+                    onClickFunction();
+                    onClick();
+                }
+            "
+            :content="tooltip"
         >
             <slot></slot>
         </button>
@@ -18,18 +28,19 @@
 </template>
 
 <script lang="ts">
+import { defineComponent } from 'vue';
 import { Vue, Prop } from 'vue-property-decorator';
 
-export default class AppbarButtonV extends Vue {
-    @Prop() onClickFunction!: any;
-    @Prop() id!: any;
-    @Prop() tooltip?: string;
-
-    onClick() {
-        //TODO: change fixtures to use this instead of click handlers in <fixture>-appbar-button?
-        this.$iApi.event.emit('appbar/click', this.id);
+export default defineComponent({
+    name: 'AppbarButtonV',
+    props: ['onClickFunction', 'id', 'tooltip', 'iApi'],
+    methods: {
+        onClick() {
+            //TODO: change fixtures to use this instead of click handlers in <fixture>-appbar-button?
+            this.iApi.event.emit('appbar/click', this.id);
+        }
     }
-}
+});
 </script>
 
 <style lang="scss" scoped>

--- a/packages/ramp-core/src/fixtures/appbar/index.ts
+++ b/packages/ramp-core/src/fixtures/appbar/index.ts
@@ -1,6 +1,7 @@
+import { createApp } from 'vue';
 import AppbarV from './appbar.vue';
 import { AppbarAPI } from './api/appbar';
-import { appbar, AppbarItemInstance, AppbarFixtureConfig } from './store';
+import { appbar, AppbarFixtureConfig } from './store';
 import { GlobalEvents, PanelInstance } from '@/api';
 import messages from './lang/lang.csv';
 
@@ -20,16 +21,24 @@ class AppbarFixture extends AppbarAPI {
         );
 
         this.$element.component('AppbarV', AppbarV);
-        // const appbarInstance = this.extend(AppbarV, {
-        //     store: this.$vApp.$store,
-        //     i18n: this.$vApp.$i18n
-        // });
 
-        // TODO: the `innerShell` reference will probably get used more than once; consider creating a dedicated ref on `$iApi`;
-        // const innerShell = this.$vApp.$el.getElementsByClassName(
-        //     'inner-shell'
-        // )[0];
-        // innerShell.insertBefore(appbarInstance.$el, innerShell.children[0]);
+        const appbarInstance = this.extend(
+            AppbarV,
+            this.$element._context.components,
+            this.$element._context.directives,
+            {
+                iApi: this.$iApi,
+                store: this.$vApp.$store,
+                i18n: <any>this.$vApp.$i18n
+            }
+        );
+        const wrapper = document.createElement('div');
+        const innerShell = this.$vApp.$el.getElementsByClassName(
+            'inner-shell'
+        )[0];
+        innerShell.appendChild(wrapper);
+        appbarInstance.mount(wrapper);
+        console.log('adding appbar to shell...', appbarInstance, wrapper);
 
         this._parseConfig(this.config);
         this.$vApp.$watch(

--- a/packages/ramp-core/src/fixtures/appbar/index.ts
+++ b/packages/ramp-core/src/fixtures/appbar/index.ts
@@ -36,8 +36,8 @@ class AppbarFixture extends AppbarAPI {
         const innerShell = this.$vApp.$el.getElementsByClassName(
             'inner-shell'
         )[0];
-        innerShell.appendChild(wrapper);
         appbarInstance.mount(wrapper);
+        innerShell.appendChild(wrapper.childNodes[0]);
         console.log('adding appbar to shell...', appbarInstance, wrapper);
 
         this._parseConfig(this.config);

--- a/packages/ramp-core/src/fixtures/appbar/more-button.vue
+++ b/packages/ramp-core/src/fixtures/appbar/more-button.vue
@@ -1,11 +1,16 @@
 <template>
     <div class="relative inset-x-0 w-full h-48 text-center">
-        <button
+        <!-- <button
             class="text-gray-400 w-full h-full focus:outline-none hover:text-white"
             @click="open = !open"
             v-focus-item
             :content="$t('appbar.more')"
             v-tippy="{ placement: 'right' }"
+        > -->
+        <button
+            class="text-gray-400 w-full h-full focus:outline-none hover:text-white"
+            @click="open = !open"
+            :content="t('appbar.more')"
         >
             <svg
                 class="fill-current w-24 h-24 m-auto"
@@ -31,13 +36,29 @@
 </template>
 
 <script lang="ts">
+import { defineComponent } from 'vue';
 import { Vue, Prop } from 'vue-property-decorator';
 
-export default class MoreAppbarButtonV extends Vue {
-    @Prop({ default: 'bottom-right' }) position!: string;
-    @Prop() tooltip?: string;
-    @Prop({ default: 'bottom' }) tooltipPlacement?: string;
-    open: boolean = false;
+export default defineComponent({
+    name: 'MoreAppbarButtonV',
+    props: {
+        position: {
+            type: String,
+            default: 'bottom-right'
+        },
+        tooltip: String,
+        tooltipPlacement: {
+            type: String,
+            default: 'bottom'
+        },
+        t: Function
+    },
+
+    data() {
+        return {
+            open: false
+        };
+    },
 
     mounted() {
         window.addEventListener(
@@ -53,7 +74,7 @@ export default class MoreAppbarButtonV extends Vue {
             { capture: true }
         );
     }
-}
+});
 </script>
 
 <style lang="scss" scoped>

--- a/packages/ramp-core/src/fixtures/appbar/nav-button.vue
+++ b/packages/ramp-core/src/fixtures/appbar/nav-button.vue
@@ -1,9 +1,15 @@
 <template>
-    <dropdown-menu
+    <!-- <dropdown-menu
         class="absolute inset-x-0 bottom-0 h-48 w-full text-center focus:outline-none"
         v-focus-item
         position="right-end"
         :tooltip="$t('appbar.navigation')"
+        tooltip-placement="right"
+    > -->
+    <dropdown-menu
+        class="absolute inset-x-0 bottom-0 h-48 w-full text-center focus:outline-none"
+        position="right-end"
+        :tooltip="t('appbar.navigation')"
         tooltip-placement="right"
     >
         <template #header>
@@ -22,33 +28,54 @@
                 </svg>
             </div>
         </template>
-        <a
+        <!-- <a
             href="#"
             class="w-160 inline-flex"
             @click="exportToggle"
             :content="$t('navigation.export-v1')"
             v-tippy="{ placement: 'right' }"
+        > -->
+        <a
+            href="#"
+            class="w-160 inline-flex"
+            @click="exportToggle"
+            :content="t('navigation.export-v1')"
         >
             <!-- https://fonts.google.com/icons?selected=Material+Icons:layers&icon.query=export -->
-            <svg class="w-24 h-24 flex-auto" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+            <svg
+                class="w-24 h-24 flex-auto"
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+            >
                 <path d="M0 0h24v24H0z" fill="none" />
                 <path d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z" />
             </svg>
             <span class="flex-auto ml-8">
-                {{ $t('map.export') }}
+                {{ t('map.export') }}
             </span>
         </a>
     </dropdown-menu>
 </template>
 
 <script lang="ts">
+import { defineComponent } from 'vue';
 import { Vue } from 'vue-property-decorator';
+// this should not need to be imported
+import DropdownMenuV from '@/components/controls/dropdown-menu.vue';
 
-export default class NavAppbarButtonV extends Vue {
-    exportToggle() {
-        this.$iApi.panel.toggle('export-v1-panel');
+export default defineComponent({
+    name: 'NavAppbarButtonV',
+    props: ['t', 'iApi'],
+    components: {
+        'dropdown-menu': DropdownMenuV
+    },
+
+    methods: {
+        exportToggle() {
+            this.iApi.panel.toggle('export-v1-panel');
+        }
     }
-}
+});
 </script>
 
 <style lang="scss" scoped></style>

--- a/packages/ramp-core/src/fixtures/basemap/appbar-button.vue
+++ b/packages/ramp-core/src/fixtures/basemap/appbar-button.vue
@@ -1,5 +1,9 @@
 <template>
-    <appbar-button :onClickFunction="onClick" :tooltip="$t('basemap.title')">
+    <appbar-button
+        :onClickFunction="onClick"
+        :tooltip="t('basemap.title')"
+        :iApi="iApi"
+    >
         <!-- Basemap icon -->
         <svg
             class="fill-current w-24 h-24 ml-8 sm:ml-20"
@@ -15,13 +19,24 @@
 </template>
 
 <script lang="ts">
+import { defineComponent } from 'vue';
 import { Vue } from 'vue-property-decorator';
+// this should not need to be imported
+import AppbarButtonV from '@/fixtures/appbar/button.vue';
 
-export default class BasemapAppbarButtonV extends Vue {
-    onClick() {
-        this.$iApi.panel.toggle('basemap-panel');
+export default defineComponent({
+    name: 'BasemapAppbarButtonV',
+    props: ['t', 'iApi'],
+    components: {
+        'appbar-button': AppbarButtonV
+    },
+
+    methods: {
+        onClick() {
+            this.iApi.panel.toggle('basemap-panel');
+        }
     }
-}
+});
 </script>
 
 <style lang="scss" scoped></style>

--- a/packages/ramp-core/src/fixtures/basemap/nav-button.vue
+++ b/packages/ramp-core/src/fixtures/basemap/nav-button.vue
@@ -1,8 +1,5 @@
 <template>
-    <mapnav-button
-        :onClickFunction="togglePanel"
-        :tooltip="$t('basemap.title')"
-    >
+    <mapnav-button :onClickFunction="togglePanel" :tooltip="t('basemap.title')">
         <svg
             class="fill-current w-32 h-20"
             xmlns="http://www.w3.org/2000/svg"
@@ -17,13 +14,24 @@
 </template>
 
 <script lang="ts">
+import { defineComponent } from 'vue';
 import { Vue } from 'vue-property-decorator';
+// this should not need to be imported
+import MapnavButtonV from '@/fixtures/mapnav/button.vue';
 
-export default class BasemapNavButtonV extends Vue {
-    togglePanel(): void {
-        const panel = this.$iApi.panel.toggle('basemap-panel');
+export default defineComponent({
+    name: 'BasemapNavButtonV',
+    props: ['t', 'iApi'],
+    components: {
+        'mapnav-button': MapnavButtonV
+    },
+
+    methods: {
+        togglePanel() {
+            const panel = this.iApi.panel.toggle('basemap-panel');
+        }
     }
-}
+});
 </script>
 
 <style lang="scss" scoped></style>

--- a/packages/ramp-core/src/fixtures/crosshairs/crosshairs.vue
+++ b/packages/ramp-core/src/fixtures/crosshairs/crosshairs.vue
@@ -78,7 +78,7 @@ export default defineComponent({
 });
 </script>
 
-<style lang="scss" scoped>
+<style lang="scss">
 .crosshairs {
     transform: translate(-50%, -50%);
 }

--- a/packages/ramp-core/src/fixtures/crosshairs/crosshairs.vue
+++ b/packages/ramp-core/src/fixtures/crosshairs/crosshairs.vue
@@ -47,29 +47,35 @@
 </template>
 
 <script lang="ts">
+import { defineComponent } from 'vue';
 import { Vue } from 'vue-property-decorator';
 import { GlobalEvents } from '@/api';
 
-export default class CrosshairsV extends Vue {
-    visible: boolean = false;
+export default defineComponent({
+    name: 'CrosshairsV',
+    data() {
+        return {
+            visible: false
+        }
+    },
 
     mounted() {
-        this.$iApi.event.on(GlobalEvents.MAP_EXTENTCHANGE, () => {
+        this.iApi.event.on(GlobalEvents.MAP_EXTENTCHANGE, () => {
             // display crosshairs if pan/zoom keys are active
-            if (this.$iApi.geo.map.keysActive) {
+            if (this.iApi.geo.map.keysActive) {
                 this.visible = true;
             }
         });
 
-        this.$iApi.event.on(GlobalEvents.MAP_MOUSEDOWN, () => {
+        this.iApi.event.on(GlobalEvents.MAP_MOUSEDOWN, () => {
             this.visible = false;
         });
 
-        this.$iApi.event.on(GlobalEvents.MAP_BLUR, () => {
+        this.iApi.event.on(GlobalEvents.MAP_BLUR, () => {
             this.visible = false;
         });
     }
-}
+});
 </script>
 
 <style lang="scss" scoped>

--- a/packages/ramp-core/src/fixtures/crosshairs/index.ts
+++ b/packages/ramp-core/src/fixtures/crosshairs/index.ts
@@ -21,7 +21,7 @@ class CrosshairsFixture extends FixtureInstance {
         );
         const wrapper = document.createElement('div');
         crosshairsInstance.mount(wrapper);
-        innerShell.appendChild(wrapper);
+        innerShell.appendChild(wrapper.childNodes[0]);
         console.log('adding crosshairs to shell...', innerShell, wrapper);
     }
 

--- a/packages/ramp-core/src/fixtures/crosshairs/index.ts
+++ b/packages/ramp-core/src/fixtures/crosshairs/index.ts
@@ -6,12 +6,23 @@ class CrosshairsFixture extends FixtureInstance {
     added(): void {
         console.log(`[fixture] ${this.id} added`);
 
-        // const innerShell = this.$vApp.$el.getElementsByClassName(
-        //     'inner-shell'
-        // )[0];
-        // const crosshairs = this.extend(CrosshairsV);
-        // innerShell.append(crosshairs.$el);
         this.$element.component('CrosshairsV', CrosshairsV);
+
+        const innerShell = this.$vApp.$el.getElementsByClassName(
+            'inner-shell'
+        )[0];
+        const crosshairsInstance = this.extend(
+            CrosshairsV,
+            this.$element._context.components,
+            this.$element._context.directives,
+            {
+                iApi: this.$iApi
+            }
+        );
+        const wrapper = document.createElement('div');
+        crosshairsInstance.mount(wrapper);
+        innerShell.appendChild(wrapper);
+        console.log('adding crosshairs to shell...', innerShell, wrapper);
     }
 
     removed(): void {

--- a/packages/ramp-core/src/fixtures/geosearch/appbar-button.vue
+++ b/packages/ramp-core/src/fixtures/geosearch/appbar-button.vue
@@ -1,5 +1,9 @@
 <template>
-    <appbar-button :onClickFunction="onClick" :tooltip="$t('geosearch.title')">
+    <appbar-button
+        :onClickFunction="onClick"
+        :tooltip="t('geosearch.title')"
+        :iApi="iApi"
+    >
         <!-- Geosearch icon -->
         <svg
             class="fill-current w-24 h-24 ml-8 sm:ml-20"
@@ -14,13 +18,24 @@
     </appbar-button>
 </template>
 <script lang="ts">
+import { defineComponent } from 'vue';
 import { Vue } from 'vue-property-decorator';
+// this should not need to be imported
+import AppbarButtonV from '@/fixtures/appbar/button.vue';
 
-export default class GeosearchAppbarButtonV extends Vue {
-    onClick() {
-        this.$iApi.panel.toggle('geosearch-panel');
+export default defineComponent({
+    name: 'GeosearchAppbarButtonV',
+    props: ['t', 'iApi'],
+    components: {
+        'appbar-button': AppbarButtonV
+    },
+
+    methods: {
+        onClick() {
+            this.iApi.panel.toggle('geosearch-panel');
+        }
     }
-}
+});
 </script>
 
 <style lang="scss" scoped></style>

--- a/packages/ramp-core/src/fixtures/help/nav-button.vue
+++ b/packages/ramp-core/src/fixtures/help/nav-button.vue
@@ -1,5 +1,5 @@
 <template>
-    <mapnav-button :onClickFunction="onClick" :tooltip="$t('help.title')">
+    <mapnav-button :onClickFunction="onClick" :tooltip="t('help.title')">
         <svg
             xmlns="http://www.w3.org/2000/svg"
             viewBox="0 0 24 24"
@@ -14,14 +14,25 @@
 </template>
 
 <script lang="ts">
+import { defineComponent } from 'vue';
 import { Vue } from 'vue-property-decorator';
 import { GlobalEvents } from '../../api/internal';
+// this should not need to be imported
+import MapnavButtonV from '@/fixtures/mapnav/button.vue';
 
-export default class HelpNavButtonV extends Vue {
-    onClick() {
-        this.$iApi.event.emit(GlobalEvents.HELP_TOGGLE);
+export default defineComponent({
+    name: 'HelpNavButtonV',
+    props: ['t', 'iApi'],
+    components: {
+        'mapnav-button': MapnavButtonV
+    },
+
+    methods: {
+        onClick() {
+            this.iApi.event.emit(GlobalEvents.HELP_TOGGLE);
+        }
     }
-}
+});
 </script>
 
 <style lang="scss" scoped></style>

--- a/packages/ramp-core/src/fixtures/legend/appbar-button.vue
+++ b/packages/ramp-core/src/fixtures/legend/appbar-button.vue
@@ -1,5 +1,9 @@
 <template>
-    <appbar-button :onClickFunction="onClick" :tooltip="$t('legend.title')">
+    <appbar-button
+        :onClickFunction="onClick"
+        :tooltip="t('legend.title')"
+        :iApi="iApi"
+    >
         <!-- https://material.io/resources/icons/?icon=layers&style=baseline -->
         <svg
             class="fill-current w-24 h-24 ml-8 sm:ml-20"
@@ -14,13 +18,24 @@
     </appbar-button>
 </template>
 <script lang="ts">
+import { defineComponent } from 'vue';
 import { Vue } from 'vue-property-decorator';
+// this should not need to be imported
+import AppbarButtonV from '@/fixtures/appbar/button.vue';
 
-export default class LegendAppbarButtonV extends Vue {
-    onClick() {
-        this.$iApi.panel.toggle('legend-panel');
+export default defineComponent({
+    name: 'LegendAppbarButtonV',
+    props: ['t', 'iApi'],
+    components: {
+        'appbar-button': AppbarButtonV
+    },
+
+    methods: {
+        onClick() {
+            this.iApi.panel.toggle('legend-panel');
+        }
     }
-}
+});
 </script>
 
 <style lang="scss" scoped></style>

--- a/packages/ramp-core/src/fixtures/mapnav/button.vue
+++ b/packages/ramp-core/src/fixtures/mapnav/button.vue
@@ -3,12 +3,17 @@
         class="relative w-32 h-32 text-gray-600 hover:text-black"
         tabindex="-1"
     >
-        <button
+        <!-- <button
             class="w-full h-full default-focus-style focus:outline-none"
             @click="onClickFunction()"
             v-focus-item
             :content="tooltip"
             v-tippy="{ placement: 'left' }"
+        > -->
+        <button
+            class="w-full h-full default-focus-style focus:outline-none"
+            @click="onClickFunction()"
+            :content="tooltip"
         >
             <slot></slot>
         </button>

--- a/packages/ramp-core/src/fixtures/mapnav/buttons/fullscreen-nav.vue
+++ b/packages/ramp-core/src/fixtures/mapnav/buttons/fullscreen-nav.vue
@@ -1,10 +1,7 @@
 <template>
-    <mapnav-button
-        :onClickFunction="onClick"
-        :tooltip="$t('mapnav.fullscreen')"
-    >
+    <mapnav-button :onClickFunction="onClick" :tooltip="t('mapnav.fullscreen')">
         <svg
-            v-if="$iApi.isFullscreen"
+            v-if="iApi.isFullscreen"
             xmlns="http://www.w3.org/2000/svg"
             viewBox="0 0 24 24"
             class="fill-current w-32 h-20"
@@ -29,13 +26,24 @@
 </template>
 
 <script lang="ts">
+import { defineComponent } from 'vue';
 import { Vue } from 'vue-property-decorator';
+// this should not need to be imported
+import MapnavButtonV from '../button.vue';
 
-export default class FullscreenNavV extends Vue {
-    onClick() {
-        this.$iApi.toggleFullscreen();
+export default defineComponent({
+    name: 'FullscreenNavV',
+    props: ['t', 'iApi'],
+    components: {
+        'mapnav-button': MapnavButtonV
+    },
+
+    methods: {
+        onClick() {
+            this.iApi.toggleFullscreen();
+        }
     }
-}
+});
 </script>
 
 <style lang="scss" scoped></style>

--- a/packages/ramp-core/src/fixtures/mapnav/buttons/home-nav.vue
+++ b/packages/ramp-core/src/fixtures/mapnav/buttons/home-nav.vue
@@ -1,5 +1,5 @@
 <template>
-    <mapnav-button :onClickFunction="goToHome" :tooltip="$t('mapnav.home')">
+    <mapnav-button :onClickFunction="goToHome" :tooltip="t('mapnav.home')">
         <svg
             xmlns="http://www.w3.org/2000/svg"
             viewBox="0 0 24 24"
@@ -12,20 +12,31 @@
 </template>
 
 <script lang="ts">
+import { defineComponent } from 'vue';
 import { Extent } from '@/geo/api';
 import { Vue } from 'vue-property-decorator';
+// this should not need to be imported
+import MapnavButtonV from '../button.vue';
 
-export default class HomeNavV extends Vue {
-    goToHome(): void {
-        // Get extent from config and convert it to extent object
-        const homeExtent = Extent.fromConfig(
-            'home_extent',
-            this.$iApi.getConfig().map.extent
-        );
-        // apply extent
-        this.$iApi.geo.map.zoomMapTo(homeExtent);
+export default defineComponent({
+    name: 'HomeNavV',
+    props: ['t', 'iApi'],
+    components: {
+        'mapnav-button': MapnavButtonV
+    },
+
+    methods: {
+        goToHome() {
+            // Get extent from config and convert it to extent object
+            const homeExtent = Extent.fromConfig(
+                'home_extent',
+                this.iApi.getConfig().map.extent
+            );
+            // apply extent
+            this.iApi.geo.map.zoomMapTo(homeExtent);
+        }
     }
-}
+});
 </script>
 
 <style lang="scss" scoped></style>

--- a/packages/ramp-core/src/fixtures/mapnav/buttons/zoom-nav.vue
+++ b/packages/ramp-core/src/fixtures/mapnav/buttons/zoom-nav.vue
@@ -1,6 +1,6 @@
 <template>
     <div>
-        <mapnav-button :onClickFunction="zoomIn" :tooltip="$t('mapnav.zoomIn')">
+        <mapnav-button :onClickFunction="zoomIn" :tooltip="t('mapnav.zoomIn')">
             <svg
                 xmlns="http://www.w3.org/2000/svg"
                 viewBox="0 0 24 24"
@@ -13,7 +13,7 @@
         <divider-nav></divider-nav>
         <mapnav-button
             :onClickFunction="zoomOut"
-            :tooltip="$t('mapnav.zoomOut')"
+            :tooltip="t('mapnav.zoomOut')"
         >
             <svg
                 xmlns="http://www.w3.org/2000/svg"
@@ -28,19 +28,34 @@
 </template>
 
 <script lang="ts">
+import { defineComponent } from 'vue';
 import { Vue, Options } from 'vue-property-decorator';
 import { throttle } from 'throttle-debounce';
 import DividerNavV from './divider-nav.vue';
+// this should not need to be imported
+import MapnavButtonV from '../button.vue';
 
-@Options({
+// @Options({
+//     components: {
+//         'divider-nav': DividerNavV
+//     }
+// })
+
+export default defineComponent({
+    name: 'ZoomNavV',
+    props: ['t', 'iApi'],
     components: {
-        'divider-nav': DividerNavV
+        'divider-nav': DividerNavV,
+        'mapnav-button': MapnavButtonV
+    },
+
+    data() {
+        return {
+            zoomIn: throttle(400, true, () => this.iApi.geo.map.zoomIn()),
+            zoomOut: throttle(400, true, () => this.iApi.geo.map.zoomOut())
+        };
     }
-})
-export default class FullscreenNavV extends Vue {
-    zoomIn = throttle(400, true, () => this.$iApi.geo.map.zoomIn());
-    zoomOut = throttle(400, true, () => this.$iApi.geo.map.zoomOut());
-}
+});
 </script>
 
 <style lang="scss" scoped></style>

--- a/packages/ramp-core/src/fixtures/mapnav/index.ts
+++ b/packages/ramp-core/src/fixtures/mapnav/index.ts
@@ -33,8 +33,8 @@ class MapnavFixture extends MapnavAPI {
         const innerShell = this.$vApp.$el.getElementsByClassName(
             'inner-shell'
         )[0];
-        innerShell.appendChild(wrapper);
         mapnavInstance.mount(wrapper);
+        innerShell.appendChild(wrapper.childNodes[0]);
         console.log('adding mapnav to shell...', mapnavInstance, wrapper);
 
         this._parseConfig(this.config);

--- a/packages/ramp-core/src/fixtures/mapnav/index.ts
+++ b/packages/ramp-core/src/fixtures/mapnav/index.ts
@@ -18,15 +18,29 @@ class MapnavFixture extends MapnavAPI {
         );
 
         this.$element.component('MapnavV', MapnavV);
-        // const mapnavInstance = this.extend(MapnavV, {
-        //     store: this.$vApp.$store,
-        //     i18n: this.$vApp.$i18n
-        // });
 
-        // // TODO: the `innerShell` reference will probably get used more than once; consider creating a dedicated ref on `$iApi`;
-        // const innerShell = this.$vApp.$el.getElementsByClassName('inner-shell')[0];
-        // innerShell.append(mapnavInstance.$el); /**, innerShell.children[0]);*/
-        // console.log(innerShell);
+        const wrapper = document.createElement('div');
+        const mapnavInstance = this.extend(
+            MapnavV,
+            this.$element._context.components,
+            this.$element._context.directives,
+            {
+                iApi: this.$iApi,
+                store: this.$vApp.$store,
+                i18n: <any>this.$vApp.$i18n
+            }
+        );
+        const innerShell = this.$vApp.$el.getElementsByClassName(
+            'inner-shell'
+        )[0];
+        innerShell.appendChild(wrapper);
+        mapnavInstance.mount(wrapper);
+        console.log(
+            'adding mapnav to shell...',
+            this.$element._context,
+            mapnavInstance,
+            wrapper
+        );
 
         this._parseConfig(this.config);
         this.$vApp.$watch(
@@ -36,7 +50,10 @@ class MapnavFixture extends MapnavAPI {
 
         // since components used in appbar can be registered after this point, listen to the global component registration event and re-validate items
         // TODO revist. this seems to be self-contained to the mapnav fixture, so ideally can stay as is and not worry about events api.
-        this.$iApi.event.on(GlobalEvents.COMPONENT, this._validateItems.bind(this));
+        this.$iApi.event.on(
+            GlobalEvents.COMPONENT,
+            this._validateItems.bind(this)
+        );
     }
 
     removed() {

--- a/packages/ramp-core/src/fixtures/mapnav/index.ts
+++ b/packages/ramp-core/src/fixtures/mapnav/index.ts
@@ -35,12 +35,7 @@ class MapnavFixture extends MapnavAPI {
         )[0];
         innerShell.appendChild(wrapper);
         mapnavInstance.mount(wrapper);
-        console.log(
-            'adding mapnav to shell...',
-            this.$element._context,
-            mapnavInstance,
-            wrapper
-        );
+        console.log('adding mapnav to shell...', mapnavInstance, wrapper);
 
         this._parseConfig(this.config);
         this.$vApp.$watch(

--- a/packages/ramp-core/src/fixtures/mapnav/mapnav.vue
+++ b/packages/ramp-core/src/fixtures/mapnav/mapnav.vue
@@ -58,7 +58,7 @@ export default defineComponent({
 });
 </script>
 
-<style lang="scss" scoped>
+<style lang="scss">
 .mapnav-section {
     @apply flex-col flex shadow-tm pointer-events-auto;
 

--- a/packages/ramp-core/src/fixtures/mapnav/mapnav.vue
+++ b/packages/ramp-core/src/fixtures/mapnav/mapnav.vue
@@ -3,11 +3,20 @@
         <div class="flex flex-col" v-focus-list>
             <zoom-nav-section
                 class="mapnav-section bg-white-75 hover:bg-white"
+                :t="i18n.t"
+                :iApi="iApi"
             ></zoom-nav-section>
             <span class="py-1"></span>
             <div class="mapnav-section bg-white-75 hover:bg-white">
-                <template v-for="(button, index) in visible" :key="button.id">
-                    <component :is="button.id + '-nav-button'"></component>
+                <template
+                    v-for="(button, index) in visible"
+                    :key="button.id + 'button'"
+                >
+                    <component
+                        :is="button.id + '-nav-button'"
+                        :t="i18n.t"
+                        :iApi="iApi"
+                    ></component>
                     <divider-nav
                         class="mapnav-divider"
                         v-if="index !== visible.length - 1"
@@ -19,30 +28,34 @@
 </template>
 
 <script lang="ts">
-import { ComputedRef } from 'vue';
+import { ComputedRef, defineComponent } from 'vue';
 import { Vue, Options } from 'vue-property-decorator';
 import { Get } from 'vuex-pathify';
 import { get } from '@/store/pathify-helper';
 
-import FullscreenNavV from './buttons/fullscreen-nav.vue';
-import HomeNavV from './buttons/home-nav.vue';
+// TODO: try to fix registered components/directives not working for child components (v-focus-list, nav-buttons, etc.)
+// NOTE: global app properties like $t, $iApi, $store are currently passed as t, iApi, store
 import ZoomNavV from './buttons/zoom-nav.vue';
 import DividerNavV from './buttons/divider-nav.vue';
-import MapnavButtonV from './button.vue';
 
-@Options({
+export default defineComponent({
+    name: 'MapnavV',
     components: {
         'divider-nav': DividerNavV,
-        'zoom-nav-section': ZoomNavV,
-        'fullscreen-nav-button': FullscreenNavV,
-        'home-nav-button': HomeNavV,
-        'mapnav-button': MapnavButtonV
+        'zoom-nav-section': ZoomNavV
+    },
+
+    data() {
+        return {
+            visible: get('mapnav/visible')
+            // @Get('mapnav/visible') visible!: any[];
+        };
+    },
+
+    created() {
+        console.log('mapnav instantiation: ', this);
     }
-})
-export default class MapNavV extends Vue {
-    visible: ComputedRef<any[]> = get('mapnav/visible');
-    // @Get('mapnav/visible') visible!: any[];
-}
+});
 </script>
 
 <style lang="scss" scoped>

--- a/packages/ramp-core/src/fixtures/northarrow/index.ts
+++ b/packages/ramp-core/src/fixtures/northarrow/index.ts
@@ -1,3 +1,4 @@
+import { createApp } from 'vue';
 import { NortharrowAPI } from './api/northarrow';
 import { northarrow, NortharrowConfig } from './store/index';
 import NortharrowV from './northarrow.vue';
@@ -15,13 +16,24 @@ class NortharrowFixture extends NortharrowAPI {
         );
 
         this.$element.component('NortharrowV', NortharrowV);
-        // const innerShell = this.$vApp.$el.getElementsByClassName(
-        //     'inner-shell'
-        // )[0];
-        // const northarrowInstance = this.extend(NortharrowV, {
-        //     store: this.$vApp.$store
-        // });
-        // innerShell.append(northarrowInstance.$el);
+
+        const wrapper = document.createElement('div');
+        const northarrowInstance = this.extend(
+            NortharrowV,
+            this.$element._context.components,
+            this.$element._context.directives,
+            {
+                iApi: this.$iApi,
+                store: this.$vApp.$store,
+                i18n: <any>this.$vApp.$i18n
+            }
+        );
+        const innerShell = this.$vApp.$el.getElementsByClassName(
+            'inner-shell'
+        )[0];
+        innerShell.appendChild(wrapper);
+        northarrowInstance.mount(wrapper);
+        console.log('adding north arrow to shell...', innerShell, wrapper);
     }
 
     removed(): void {

--- a/packages/ramp-core/src/fixtures/northarrow/index.ts
+++ b/packages/ramp-core/src/fixtures/northarrow/index.ts
@@ -31,8 +31,8 @@ class NortharrowFixture extends NortharrowAPI {
         const innerShell = this.$vApp.$el.getElementsByClassName(
             'inner-shell'
         )[0];
-        innerShell.appendChild(wrapper);
         northarrowInstance.mount(wrapper);
+        innerShell.appendChild(wrapper.childNodes[0]);
         console.log('adding north arrow to shell...', innerShell, wrapper);
     }
 

--- a/packages/ramp-core/src/fixtures/northarrow/northarrow.vue
+++ b/packages/ramp-core/src/fixtures/northarrow/northarrow.vue
@@ -176,4 +176,4 @@ export default defineComponent({
 });
 </script>
 
-<style lang="scss" scoped></style>
+<style lang="scss"></style>

--- a/packages/ramp-core/src/fixtures/northarrow/northarrow.vue
+++ b/packages/ramp-core/src/fixtures/northarrow/northarrow.vue
@@ -44,7 +44,6 @@ export default defineComponent({
     },
 
     mounted() {
-        console.log('northarrow mounted: ', this);
         if (this.arrowIcon.value) {
             this.arrow = `<img width='25' src='${this.arrowIcon.value}'>`;
         }

--- a/packages/ramp-core/src/fixtures/northarrow/northarrow.vue
+++ b/packages/ramp-core/src/fixtures/northarrow/northarrow.vue
@@ -1,11 +1,14 @@
 <template>
-    <div class="absolute transition-all duration-300 ease-out" :style="arrowStyle">
+    <div
+        class="absolute transition-all duration-300 ease-out"
+        :style="getArrowStyle()"
+    >
         <span class="northarrow" v-html="arrow"></span>
     </div>
 </template>
 
 <script lang="ts">
-import { ComputedRef } from 'vue';
+import { ComputedRef, defineComponent } from 'vue';
 import { Vue } from 'vue-property-decorator';
 import { Get } from 'vuex-pathify';
 import { get } from '@/store/pathify-helper';
@@ -15,128 +18,163 @@ import { Extent, Point } from '@/geo/api';
 import flag from './flag.json';
 import { debounce } from 'throttle-debounce';
 
-export default class NortharrowV extends Vue {
-    arrowIcon: ComputedRef<string> = get(NortharrowStore.arrowIcon);
-    poleIcon: ComputedRef<string> = get(NortharrowStore.poleIcon);
-    // @Get(NortharrowStore.arrowIcon) arrowIcon!: string;
-    // @Get(NortharrowStore.poleIcon) poleIcon!: string;
-
-    angle: number = 0;
-    arrowLeft: number = 0;
-    displayArrow: boolean = false;
-    arrow: string = `<svg xmlns="http://www.w3.org/2000/svg" fit=""  width="25" preserveAspectRatio="xMidYMid meet" viewBox="0 0 24 24" focusable="false">
-            <g id="northarrow" transform="translate(-285.24 -142.234)">
-                <path id="path3770-7" d="M305.91 156.648a8.652 8.652 0 0 1-8.654 8.653 8.652 8.652 0 0 1-8.653-8.653 8.653 8.653 0 0 1 8.653-8.653 8.653 8.653 0 0 1 8.653 8.653z" fill="#fff" stroke="#fff" stroke-width=".895"/>
-                <path id="path3770" d="M304.982 156.648a7.725 7.725 0 0 1-7.726 7.726 7.725 7.725 0 0 1-7.726-7.726 7.725 7.725 0 0 1 7.726-7.726 7.725 7.725 0 0 1 7.726 7.726z" fill="none" stroke="#6d6d6d" stroke-width=".799"/>
-                <path id="path3774" d="M297.256 156.648v-8.525" fill="none" stroke="#000" stroke-width=".067"/>
-                <path d="M297.258 143.48l8.793 22.432-8.811-8.812-8.812 8.812z" id="path3778" fill="#fff" stroke="#fff" stroke-width=".912"/>
-                <path d="M297.256 144.805l7.726 19.568-7.726-7.726-7.726 7.726z" id="path3780" fill="#d6d6d6" stroke="#000" stroke-width=".266" stroke-linecap="square"/>
-                <path id="path6038" d="M297.256 144.666l-7.726 19.568 7.726-7.726" fill="#6d6d6d" stroke-width=".296" stroke-linecap="square"/>
-            </g>
-        </svg>`;
-    poleMarkerAdded: boolean = false;
+export default defineComponent({
+    name: 'NortharrowV',
+    data() {
+        return {
+            arrowIcon: get(NortharrowStore.arrowIcon),
+            poleIcon: get(NortharrowStore.poleIcon),
+            // @Get(NortharrowStore.arrowIcon) arrowIcon!: string;
+            // @Get(NortharrowStore.poleIcon) poleIcon!: string;
+            angle: 0,
+            arrowLeft: 0,
+            displayArrow: false,
+            arrow: `<svg xmlns="http://www.w3.org/2000/svg" fit=""  width="25" preserveAspectRatio="xMidYMid meet" viewBox="0 0 24 24" focusable="false">
+                <g id="northarrow" transform="translate(-285.24 -142.234)">
+                    <path id="path3770-7" d="M305.91 156.648a8.652 8.652 0 0 1-8.654 8.653 8.652 8.652 0 0 1-8.653-8.653 8.653 8.653 0 0 1 8.653-8.653 8.653 8.653 0 0 1 8.653 8.653z" fill="#fff" stroke="#fff" stroke-width=".895"/>
+                    <path id="path3770" d="M304.982 156.648a7.725 7.725 0 0 1-7.726 7.726 7.725 7.725 0 0 1-7.726-7.726 7.725 7.725 0 0 1 7.726-7.726 7.725 7.725 0 0 1 7.726 7.726z" fill="none" stroke="#6d6d6d" stroke-width=".799"/>
+                    <path id="path3774" d="M297.256 156.648v-8.525" fill="none" stroke="#000" stroke-width=".067"/>
+                    <path d="M297.258 143.48l8.793 22.432-8.811-8.812-8.812 8.812z" id="path3778" fill="#fff" stroke="#fff" stroke-width=".912"/>
+                    <path d="M297.256 144.805l7.726 19.568-7.726-7.726-7.726 7.726z" id="path3780" fill="#d6d6d6" stroke="#000" stroke-width=".266" stroke-linecap="square"/>
+                    <path id="path6038" d="M297.256 144.666l-7.726 19.568 7.726-7.726" fill="#6d6d6d" stroke-width=".296" stroke-linecap="square"/>
+                </g>
+            </svg>`,
+            poleMarkerAdded: false
+        };
+    },
 
     mounted() {
+        console.log('northarrow mounted: ', this);
         if (this.arrowIcon.value) {
             this.arrow = `<img width='25' src='${this.arrowIcon.value}'>`;
         }
         // don't think this condition should be needed but sometimes errors at startup without it
-        if (this.$iApi.geo.map.esriView?.ready) {
-            this.updateNortharrow(this.$iApi.geo.map.getExtent());
+        if (this.iApi.geo.map.esriView?.ready) {
+            this.updateNortharrow(this.iApi.geo.map.getExtent());
         }
-        this.$iApi.event.on(GlobalEvents.MAP_EXTENTCHANGE, debounce(300, this.updateNortharrow));
-    }
+        this.iApi.event.on(
+            GlobalEvents.MAP_EXTENTCHANGE,
+            debounce(300, this.updateNortharrow)
+        );
+    },
 
-    async updateNortharrow(newExtent: Extent) {
-        const innerShell = document.querySelector('.inner-shell')!;
-        const arrowWidth = this.$el.querySelector('.northarrow')!.getBoundingClientRect().width;
-        const appbarWidth = document.querySelector('.appbar')?.clientWidth || 0;
-        const sr = newExtent.sr;
-        const mercator = [900913, 3587, 54004, 41001, 102113, 102100, 3785];
-        if ((sr.wkid && mercator.includes(sr.wkid)) || (sr.latestWkid && mercator.includes(sr.latestWkid))) {
-            // mercator projection, always in center of viewer with no rotation
-            this.displayArrow = true;
-            this.angle = 0;
-            this.arrowLeft = appbarWidth + (innerShell.clientWidth - appbarWidth - arrowWidth) / 2;
-        } else {
-            // north value (set longitude to be half of Canada extent (141° W, 52° W))
-            const pole: Point = new Point('pole', { x: -96, y: 90 });
-            const projPole = (await this.$iApi.geo.utils.proj.projectGeometry(sr, pole)) as Point;
-            const poleScreenPos = this.$iApi.geo.map.mapPointToScreenPoint(projPole);
-            if (poleScreenPos.screenY < 0) {
-                // draw arrow if pole not visibile
+    methods: {
+        async updateNortharrow(newExtent: Extent) {
+            const innerShell = document.querySelector('.inner-shell')!;
+            const arrowWidth = this.$el
+                .querySelector('.northarrow')!
+                .getBoundingClientRect().width;
+            const appbarWidth =
+                document.querySelector('.appbar')?.clientWidth || 0;
+            const sr = newExtent.sr;
+            const mercator = [900913, 3587, 54004, 41001, 102113, 102100, 3785];
+            if (
+                (sr.wkid && mercator.includes(sr.wkid)) ||
+                (sr.latestWkid && mercator.includes(sr.latestWkid))
+            ) {
+                // mercator projection, always in center of viewer with no rotation
                 this.displayArrow = true;
-                // get angle from bottom centre
-                const bcScreenPos = {
-                    screenX: innerShell.clientWidth / 2,
-                    screenY: innerShell.clientHeight
-                };
-                this.angle =
-                    (Math.atan(
-                        (poleScreenPos.screenX - bcScreenPos.screenX) / (bcScreenPos.screenY - poleScreenPos.screenY)
-                    ) *
-                        180) /
-                    Math.PI;
+                this.angle = 0;
                 this.arrowLeft =
-                    innerShell.clientWidth / 2 +
-                    innerShell.clientHeight * Math.tan((this.angle * Math.PI) / 180) -
-                    arrowWidth / 2;
-                // make sure arrow is within visible part of map
-                this.arrowLeft = Math.max(
-                    appbarWidth - arrowWidth / 2,
-                    Math.min(this.$iApi.geo.map.getPixelWidth() - arrowWidth / 2, this.arrowLeft)
-                );
+                    appbarWidth +
+                    (innerShell.clientWidth - appbarWidth - arrowWidth) / 2;
             } else {
-                // add pole marker if visible
-                this.displayArrow = false;
-                if (!this.poleMarkerAdded) {
-                    this.poleMarkerAdded = true;
-                    // TODO update to use RAMP API Styles once Highlight Layer implements an api that accepts RAMP Graphics. Get rid of all ESRI stuff when that happens
-                    let markerSymbol: any = flag;
-                    if (this.poleIcon.value) {
-                        // convert data uri to esri symbol json
-                        const [, contentType, , imageData] = this.poleIcon.value.split(/[:;,]/);
-                        markerSymbol = {
-                            width: 16.5,
-                            height: 16.5,
-                            type: 'esriPMS',
-                            contentType: contentType,
-                            imageData: imageData
-                        };
-                    }
-                    // add pole marker to a highlight layer
-                    // TODO the whole highlight layer needs to be revisited after the no-dojo migration.
-                    //      it is currently acting like a normal layer. since highlights do not go into the
-                    //      layer config / config store / etc, we are duplicating a lot of normal layer loading
-                    //      here. hack city for now.
+                // north value (set longitude to be half of Canada extent (141° W, 52° W))
+                const pole: Point = new Point('pole', { x: -96, y: 90 });
+                const projPole = (await this.iApi.geo.utils.proj.projectGeometry(
+                    sr,
+                    pole
+                )) as Point;
+                const poleScreenPos = this.iApi.geo.map.mapPointToScreenPoint(
+                    projPole
+                );
+                if (poleScreenPos.screenY < 0) {
+                    // draw arrow if pole not visibile
+                    this.displayArrow = true;
+                    // get angle from bottom centre
+                    const bcScreenPos = {
+                        screenX: innerShell.clientWidth / 2,
+                        screenY: innerShell.clientHeight
+                    };
+                    this.angle =
+                        (Math.atan(
+                            (poleScreenPos.screenX - bcScreenPos.screenX) /
+                                (bcScreenPos.screenY - poleScreenPos.screenY)
+                        ) *
+                            180) /
+                        Math.PI;
+                    this.arrowLeft =
+                        innerShell.clientWidth / 2 +
+                        innerShell.clientHeight *
+                            Math.tan((this.angle * Math.PI) / 180) -
+                        arrowWidth / 2;
+                    // make sure arrow is within visible part of map
+                    this.arrowLeft = Math.max(
+                        appbarWidth - arrowWidth / 2,
+                        Math.min(
+                            this.iApi.geo.map.getPixelWidth() - arrowWidth / 2,
+                            this.arrowLeft
+                        )
+                    );
+                } else {
+                    // add pole marker if visible
+                    this.displayArrow = false;
+                    if (!this.poleMarkerAdded) {
+                        this.poleMarkerAdded = true;
+                        // TODO update to use RAMP API Styles once Highlight Layer implements an api that accepts RAMP Graphics. Get rid of all ESRI stuff when that happens
+                        let markerSymbol: any = flag;
+                        if (this.poleIcon.value) {
+                            // convert data uri to esri symbol json
+                            const [
+                                ,
+                                contentType,
+                                ,
+                                imageData
+                            ] = this.poleIcon.value.split(/[:;,]/);
+                            markerSymbol = {
+                                width: 16.5,
+                                height: 16.5,
+                                type: 'esriPMS',
+                                contentType: contentType,
+                                imageData: imageData
+                            };
+                        }
+                        // add pole marker to a highlight layer
+                        // TODO the whole highlight layer needs to be revisited after the no-dojo migration.
+                        //      it is currently acting like a normal layer. since highlights do not go into the
+                        //      layer config / config store / etc, we are duplicating a lot of normal layer loading
+                        //      here. hack city for now.
 
-                    // check if we need to load the layer class
-                    const lType = 'highlight';
-                    if (!this.$iApi.geo.layer.layerDefExists(lType)) {
-                        await this.$iApi.geo.layer.addLayerDef(lType);
+                        // check if we need to load the layer class
+                        const lType = 'highlight';
+                        if (!this.iApi.geo.layer.layerDefExists(lType)) {
+                            await this.iApi.geo.layer.addLayerDef(lType);
+                        }
+                        const poleLayer = await this.iApi.geo.layer.createLayer(
+                            {
+                                layerId: 'PoleMarker',
+                                markerSymbol: markerSymbol,
+                                layerType: 'highlight'
+                            }
+                        );
+                        await poleLayer.initiate();
+                        (poleLayer as any).addMarker(projPole); // since addMarker is not a standard layer interface function, we need to cast as any.
+                        this.iApi.geo.map.addLayer(poleLayer);
                     }
-                    const poleLayer = await this.$iApi.geo.layer.createLayer({
-                        layerId: 'PoleMarker',
-                        markerSymbol: markerSymbol,
-                        layerType: 'highlight'
-                    });
-                    await poleLayer.initiate();
-                    (poleLayer as any).addMarker(projPole); // since addMarker is not a standard layer interface function, we need to cast as any.
-                    this.$iApi.geo.map.addLayer(poleLayer);
                 }
             }
+        },
+
+        getArrowStyle() {
+            return {
+                'transform-origin': `top center`,
+                transform: `rotate(${this.angle}deg)`,
+                left: `${this.arrowLeft}px`,
+                visibility: this.displayArrow ? `visible` : `hidden`
+            };
         }
     }
-
-    get arrowStyle() {
-        return {
-            'transform-origin': `top center`,
-            transform: `rotate(${this.angle}deg)`,
-            left: `${this.arrowLeft}px`,
-            visibility: this.displayArrow ? `visible` : `hidden`
-        };
-    }
-}
+});
 </script>
 
 <style lang="scss" scoped></style>

--- a/packages/ramp-core/src/fixtures/overviewmap/index.ts
+++ b/packages/ramp-core/src/fixtures/overviewmap/index.ts
@@ -37,6 +37,7 @@ class OverviewmapFixture extends OverviewmapAPI {
         const wrapper = document.createElement('div');
         overviewInstance.mount(wrapper);
         innerShell.appendChild(wrapper);
+        console.log('adding overview map to shell...', innerShell, wrapper);
     }
 
     removed() {

--- a/packages/ramp-core/src/fixtures/overviewmap/index.ts
+++ b/packages/ramp-core/src/fixtures/overviewmap/index.ts
@@ -36,7 +36,7 @@ class OverviewmapFixture extends OverviewmapAPI {
         );
         const wrapper = document.createElement('div');
         overviewInstance.mount(wrapper);
-        innerShell.appendChild(wrapper);
+        innerShell.appendChild(wrapper.childNodes[0]);
         console.log('adding overview map to shell...', innerShell, wrapper);
     }
 

--- a/packages/ramp-core/src/fixtures/overviewmap/index.ts
+++ b/packages/ramp-core/src/fixtures/overviewmap/index.ts
@@ -20,14 +20,23 @@ class OverviewmapFixture extends OverviewmapAPI {
         );
 
         this.$element.component('OverviewmapV', OverviewmapV);
-        // const innerShell = this.$vApp.$el.getElementsByClassName(
-        //     'inner-shell'
-        // )[0];
-        // const overviewInstance = this.extend(OverviewmapV, {
-        //     store: this.$vApp.$store,
-        //     i18n: this.$vApp.$i18n
-        // });
-        // innerShell.append(overviewInstance.$el);
+
+        const innerShell = this.$vApp.$el.getElementsByClassName(
+            'inner-shell'
+        )[0];
+        const overviewInstance = this.extend(
+            OverviewmapV,
+            this.$element._context.components,
+            this.$element._context.directives,
+            {
+                iApi: this.$iApi,
+                store: this.$vApp.$store,
+                i18n: <any>this.$vApp.$i18n
+            }
+        );
+        const wrapper = document.createElement('div');
+        overviewInstance.mount(wrapper);
+        innerShell.appendChild(wrapper);
     }
 
     removed() {

--- a/packages/ramp-core/src/fixtures/overviewmap/overviewmap.vue
+++ b/packages/ramp-core/src/fixtures/overviewmap/overviewmap.vue
@@ -149,7 +149,7 @@ export default defineComponent({
 });
 </script>
 
-<style lang="scss" scoped>
+<style lang="scss">
 .overviewmap::before {
     @apply absolute w-0 h-0 top-0 right-0 border-solid;
     border-width: 0 40px 40px 0;

--- a/packages/ramp-core/src/fixtures/panguard/index.ts
+++ b/packages/ramp-core/src/fixtures/panguard/index.ts
@@ -10,11 +10,25 @@ class PanguardFixture extends FixtureInstance {
             (<any>this.$vApp.$i18n).mergeLocaleMessage(...value)
         );
 
-        // const panguard = this.extend(PanguardV);
-        // this.$vApp.$root
-        //     ? this.$vApp.$root.$el.getElementsByClassName('inner-shell')[0].prepend(panguard.$el)
-        //     : undefined;
         this.$element.component('PanguardV', PanguardV);
+
+        const innerShell = this.$vApp.$el.getElementsByClassName(
+            'inner-shell'
+        )[0];
+        const panguardInstance = this.extend(
+            PanguardV,
+            this.$element._context.components,
+            this.$element._context.directives,
+            {
+                iApi: this.$iApi,
+                store: this.$vApp.$store,
+                i18n: <any>this.$vApp.$i18n
+            }
+        );
+        const wrapper = document.createElement('div');
+        panguardInstance.mount(wrapper);
+        innerShell.appendChild(wrapper.childNodes[0]);
+        console.log('adding panguard to shell...', this.$element, wrapper);
     }
 
     removed(): void {

--- a/packages/ramp-core/src/fixtures/panguard/map-panguard.vue
+++ b/packages/ramp-core/src/fixtures/panguard/map-panguard.vue
@@ -1,29 +1,37 @@
 <template>
     <div class="pan-guard" ref="panGuard">
-        <p class="label">{{ $t('panguard.instructions') }}</p>
+        <p class="label">{{ i18n.t('panguard.instructions') }}</p>
     </div>
 </template>
 
 <script lang="ts">
+import { defineComponent } from 'vue';
 import { Vue } from 'vue-property-decorator';
 
-export default class MapPanguardV extends Vue {
-    timeoutID: number | undefined = undefined;
+export default defineComponent({
+    name: 'MapPanguardV',
+    data(): {
+        timeoutID: number | undefined;
+    } {
+        return {
+            timeoutID: undefined
+        };
+    },
 
-    mounted(): void {
+    mounted() {
         // keep track of how many concurrent pointers are on the screen and their initial positions. This is a javascript map, not a map-map
         const pointers = new Map();
 
         // prevent possible issues with esri event registration if this fixture runs before the map has built itself
-        this.$iApi.geo.map.viewPromise.then(() => {
+        this.iApi.geo.map.viewPromise.then(() => {
             // TODO: when projection change is implemented check that the below events track any changes to
             // the esriView or update MapAPI to be raising pointer events on the EventAPI, and this will listen to for those events
-            this.$iApi.geo.map.esriView!.on('pointer-down', e => {
+            this.iApi.geo.map.esriView!.on('pointer-down', e => {
                 if (e.pointerType !== 'touch') return;
                 pointers.set(e.pointerId, { x: e.x, y: e.y });
             });
 
-            this.$iApi.geo.map.esriView!.on(
+            this.iApi.geo.map.esriView!.on(
                 ['pointer-up', 'pointer-leave'],
                 e => {
                     if (e.pointerType !== 'touch') return;
@@ -31,7 +39,7 @@ export default class MapPanguardV extends Vue {
                 }
             );
 
-            this.$iApi.geo.map.esriView!.on('pointer-move', e => {
+            this.iApi.geo.map.esriView!.on('pointer-move', e => {
                 const { pointerId, pointerType, x, y } = e;
                 const pointer = pointers.get(pointerId);
 
@@ -56,10 +64,10 @@ export default class MapPanguardV extends Vue {
             });
         });
     }
-}
+});
 </script>
 
-<style lang="scss" scoped>
+<style lang="scss">
 .pan-guard {
     transition: opacity ease-in-out;
     background-color: rgba(0, 0, 0, 0.45);

--- a/packages/ramp-core/src/fixtures/scrollguard/index.ts
+++ b/packages/ramp-core/src/fixtures/scrollguard/index.ts
@@ -10,11 +10,25 @@ class ScrollguardFixture extends FixtureInstance {
             (<any>this.$vApp.$i18n).mergeLocaleMessage(...value)
         );
 
-        // const scrollguard = this.extend(ScrollguardV);
-        // this.$vApp.$root.$el
-        //     .getElementsByClassName('inner-shell')[0]
-        //     .prepend(scrollguard.$el);
         this.$element.component('ScrollguardV', ScrollguardV);
+
+        const innerShell = this.$vApp.$el.getElementsByClassName(
+            'inner-shell'
+        )[0];
+        const scrollguardInstance = this.extend(
+            ScrollguardV,
+            this.$element._context.components,
+            this.$element._context.directives,
+            {
+                iApi: this.$iApi,
+                store: this.$vApp.$store,
+                i18n: <any>this.$vApp.$i18n
+            }
+        );
+        const wrapper = document.createElement('div');
+        scrollguardInstance.mount(wrapper);
+        innerShell.appendChild(wrapper);
+        console.log('adding scrollguard to shell...', innerShell, wrapper);
     }
 
     removed(): void {

--- a/packages/ramp-core/src/fixtures/scrollguard/index.ts
+++ b/packages/ramp-core/src/fixtures/scrollguard/index.ts
@@ -27,7 +27,7 @@ class ScrollguardFixture extends FixtureInstance {
         );
         const wrapper = document.createElement('div');
         scrollguardInstance.mount(wrapper);
-        innerShell.appendChild(wrapper);
+        innerShell.appendChild(wrapper.childNodes[0]);
         console.log('adding scrollguard to shell...', innerShell, wrapper);
     }
 

--- a/packages/ramp-core/src/fixtures/scrollguard/map-scrollguard.vue
+++ b/packages/ramp-core/src/fixtures/scrollguard/map-scrollguard.vue
@@ -1,41 +1,45 @@
 <template>
     <div class="sg" ref="scrollGuard">
-        <p class="sg-label">{{ $t('scrollguard.instructions') }}</p>
+        <p class="sg-label">{{ i18n.t('scrollguard.instructions') }}</p>
     </div>
 </template>
 
 <script lang="ts">
+import { defineComponent } from 'vue';
 import { Vue } from 'vue-property-decorator';
 
-export default class MapScrollguardV extends Vue {
-    mounted(): void {
-        (this.$iApi.$vApp.$el.querySelector(
+export default defineComponent({
+    name: 'MapScrollguardV',
+    mounted() {
+        (this.iApi.$vApp.$el.querySelector(
             '.inner-shell + .esri-view'
         )! as HTMLElement).addEventListener('wheel', this.wheelHandler, {
             capture: true
         });
-    }
+    },
 
-    wheelHandler(event: WheelEvent): void {
-        const scrollGuardClassList = this.$el.classList;
+    methods: {
+        wheelHandler(event: WheelEvent) {
+            const scrollGuardClassList = this.$el.classList;
 
-        // prevent scroll unless ctrlKey is depressed
-        if (!event.ctrlKey) {
-            event.stopPropagation();
-            scrollGuardClassList.remove('sg-scrolling');
-            scrollGuardClassList.add('sg-active');
+            // prevent scroll unless ctrlKey is depressed
+            if (!event.ctrlKey) {
+                event.stopPropagation();
+                scrollGuardClassList.remove('sg-scrolling');
+                scrollGuardClassList.add('sg-active');
 
-            // remove scroll guard notification after two seconds
-            window.setTimeout(
-                () => scrollGuardClassList.remove('sg-active'),
-                2000
-            );
-        } else {
-            scrollGuardClassList.remove('sg-active');
-            scrollGuardClassList.add('sg-scrolling');
+                // remove scroll guard notification after two seconds
+                window.setTimeout(
+                    () => scrollGuardClassList.remove('sg-active'),
+                    2000
+                );
+            } else {
+                scrollGuardClassList.remove('sg-active');
+                scrollGuardClassList.add('sg-scrolling');
+            }
         }
     }
-}
+});
 </script>
 
 <style lang="scss" scoped>

--- a/packages/ramp-core/src/fixtures/scrollguard/map-scrollguard.vue
+++ b/packages/ramp-core/src/fixtures/scrollguard/map-scrollguard.vue
@@ -42,7 +42,7 @@ export default defineComponent({
 });
 </script>
 
-<style lang="scss" scoped>
+<style lang="scss">
 .sg {
     transition: opacity ease-in-out;
     background-color: rgba(0, 0, 0, 0.45);

--- a/packages/ramp-core/src/fixtures/snowman/index.ts
+++ b/packages/ramp-core/src/fixtures/snowman/index.ts
@@ -16,7 +16,7 @@ class SnowmanFixture extends FixtureInstance {
             propsData: { message: "I'm snowman prop." }
         });
 
-        this.$vApp.$el.appendChild(snowman.$el);
+        this.$vApp.$el.appendChild(snowman);
 
         // snowman self-terminates from its own component
 

--- a/packages/ramp-core/src/geo/map/common-map.ts
+++ b/packages/ramp-core/src/geo/map/common-map.ts
@@ -5,6 +5,7 @@
 
 // TODO add proper comments
 
+import { toRaw, markRaw } from 'vue';
 import { APIScope, Basemap, GlobalEvents, InstanceAPI } from '@/api/internal';
 import { EsriMap } from '@/geo/esri';
 import { RampMapConfig } from '@/geo/api';
@@ -27,18 +28,22 @@ export class CommonMapAPI extends APIScope {
     // will generate the actual Map control objects, put it on the page
     createMap(config: RampMapConfig, targetDiv: string | HTMLDivElement): void {
         // TODO if .esriMap exists, do we want to do any cleanup on it? E.g. remove event handlers?
-
-        this._basemapStore = config.basemaps.map(bmConfig => new Basemap(bmConfig));
-
+        this._basemapStore = config.basemaps.map(
+            bmConfig => new Basemap(bmConfig)
+        );
         const esriConfig: __esri.MapProperties = {};
         if (config.initialBasemapId) {
-            esriConfig.basemap = this.findBasemap(config.initialBasemapId).innerBasemap;
+            esriConfig.basemap = toRaw(
+                this.findBasemap(config.initialBasemapId).innerBasemap
+            );
         }
-        this.esriMap = new EsriMap(esriConfig);
+        this.esriMap = markRaw(new EsriMap(esriConfig));
     }
 
     protected findBasemap(id: string): Basemap {
-        const bm: Basemap | undefined = this._basemapStore.find(bms => bms.id === id);
+        const bm: Basemap | undefined = this._basemapStore.find(
+            bms => bms.id === id
+        );
         if (bm) {
             return bm;
         } else {
@@ -69,7 +74,9 @@ export class CommonMapAPI extends APIScope {
     }
 
     protected noMapErr(): void {
-        console.error('Attempted to manipulate the map before calling createMap()');
+        console.error(
+            'Attempted to manipulate the map before calling createMap()'
+        );
     }
 
     // TODO shared Map (not view-based) functions could go here.

--- a/packages/ramp-core/src/geo/map/overview-map.ts
+++ b/packages/ramp-core/src/geo/map/overview-map.ts
@@ -1,3 +1,4 @@
+import { markRaw } from 'vue';
 import { CommonMapAPI, InstanceAPI } from '@/api/internal';
 import {
     BaseGeometry,
@@ -64,7 +65,7 @@ export class OverviewMapAPI extends CommonMapAPI {
             extent: config.extent
         };
 
-        this.esriView = new EsriMapView(esriViewConfig);
+        this.esriView = markRaw(new EsriMapView(esriViewConfig));
         this.esriView.ui.components = [];
 
         // initialize extent rectangle graphic
@@ -125,8 +126,9 @@ export class OverviewMapAPI extends CommonMapAPI {
         if (esriDrag.action === 'start') {
             // check if drag hits graphic, if so set start extent
             if (await this.cursorHitTest(esriDrag)) {
-                this.startExtent = this.esriView!.graphics.getItemAt(0)
-                    .geometry as __esri.Extent;
+                this.startExtent = markRaw(
+                    this.esriView!.graphics.getItemAt(0).geometry
+                ) as __esri.Extent;
             }
         } else if (this.startExtent) {
             // determine delta in map coords from drag origin to current drag point and update extent graphic

--- a/packages/ramp-core/src/lang/index.ts
+++ b/packages/ramp-core/src/lang/index.ts
@@ -20,5 +20,6 @@ export const i18n = createI18n({
     // get the language of the page from the root `html` node
     locale: document.documentElement!.getAttribute('lang') || lang,
     fallbackLocale: lang,
+    globalInjection: true,
     messages: messages
 });

--- a/packages/ramp-core/src/shims-vuex.d.ts
+++ b/packages/ramp-core/src/shims-vuex.d.ts
@@ -9,6 +9,8 @@ declare module '@vue/runtime-core' {
 
         $iApi: InstanceAPI;
 
+        iApi: InstanceAPI;
+
         $formulate: FormulateGlobalInstance;
     }
 }

--- a/packages/ramp-core/src/store/pathify-helper.js
+++ b/packages/ramp-core/src/store/pathify-helper.js
@@ -12,7 +12,6 @@ export function get(path) {
     return property;
 }
 
-// have not tested this yet (don't use) since @Sync appears to not be giving any console errors
 export function sync(path) {
     return computed({
         get() {


### PR DESCRIPTION
Work on appbar, mapnav, crosshairs, panguard, scrollguard, north arrow and overview map fixtures. They all should be appearing on the map and the functionality should work for the most part (outside of a few panels not opening and possibly regression bugs). 

Went with a strategy using `createApp` and `mount` to replicate the `Vue.extend` behavior but if there is a way to register them as components and position them with `teleport to` I'm down to switch to that (I didn't know how to pull that off). We can also apply Vue teleport in each of the fixtures and add the mounted dynamic components anywhere inside the app container as an alternative if it is not good to directly append it to `inner-shell` (altho I don't see much difference there).

Also refactored all these Vue components to be declared using `defineComponent` since we will be migrating to that anyway for composition API eventually. This would spell the end of `vue-property decorator` ?

Some concerns (just for reference):
- biggest one being the need of a way to pass parent registered components/directives (resulting in alot of unnecessary imports to get everything running) as well as a better way to pass properties such as `$iApi`, `$t` to child components (commented out sections of these children templates that create errors - mostly involving `v-tippy`)
- used `defineComponent({ extends: ...})` behavior but this erases the `$` in front of properties like `iApi`, `store`, `i18n`
- `$t` still doesn't seem to work - had to use `i18n.t(...)` as a replacement
- the appbar `updated()` code needs to be updated

[Demo](http://ramp4-app.azureedge.net/demo/users/yileifeng/dynamic-component-creation/host/index.html)