### PR TITLE
fix details fixture; other small fixes

### DIFF
--- a/packages/ramp-core/public/ramp-starter.js
+++ b/packages/ramp-core/public/ramp-starter.js
@@ -180,12 +180,20 @@ let config = {
                 }
             },
             appbar: {
-                items: [
-                    'legend',
-                    'geosearch',
-                    'basemap',
-                ],
+                items: ['legend', 'geosearch', 'basemap'],
                 temporaryButtons: ['details', 'grid']
+            },
+            details: {
+                items: [
+                    {
+                        id: 'WaterQuantity',
+                        template: 'Water-Quantity-Template'
+                    },
+                    {
+                        id: 'WFSLayer',
+                        template: 'WFSLayer-Custom'
+                    }
+                ]
             },
             mapnav: { items: ['fullscreen', 'help', 'home', 'basemap'] },
             'export-v1-title': {
@@ -255,11 +263,7 @@ let config = {
         ],
         fixtures: {
             appbar: {
-                items: [
-                    'legend',
-                    'geosearch',
-                    'basemap',
-                ],
+                items: ['legend', 'geosearch', 'basemap'],
                 temporaryButtons: ['details', 'grid']
             },
             mapnav: { items: ['fullscreen', 'help', 'home', 'basemap'] },
@@ -279,6 +283,16 @@ let options = {
 rInstance = new RAMP.Instance(document.getElementById('app'), config, options);
 rInstance.fixture.addDefaultFixtures().then(() => {
     rInstance.panel.open('legend-panel');
+});
+
+rInstance.$element.component('WFSLayer-Custom', {
+    props: ['identifyData'],
+    template: `
+        <div>
+            <span>This is an example template that contains an image.</span>
+            <img src="https://i.imgur.com/WtY0tdC.gif" />
+        </div>
+    `
 });
 
 // add export-v1 fixtures

--- a/packages/ramp-core/public/starter-scripts/panel-party.js
+++ b/packages/ramp-core/public/starter-scripts/panel-party.js
@@ -348,8 +348,7 @@ rInstance.fixture.addDefaultFixtures().then(() => {
 });
 
 // Load custom templates.
-
-Vue.component('WFSLayer-Custom', {
+rInstance.$element.component('WFSLayer-Custom', {
     props: ['identifyData'],
     render: function(h) {
         return h('div', [

--- a/packages/ramp-core/src/api/event.ts
+++ b/packages/ramp-core/src/api/event.ts
@@ -17,6 +17,7 @@ import {
 import { RampConfig } from '@/types';
 import { debounce, throttle } from 'throttle-debounce';
 import { MapCaptionStore } from '@/store/modules/map-caption';
+import { reactive } from 'vue';
 
 export enum GlobalEvents {
     /**

--- a/packages/ramp-core/src/api/instance.ts
+++ b/packages/ramp-core/src/api/instance.ts
@@ -185,7 +185,7 @@ export class InstanceAPI {
         if (!this.$element || !this.$element._container) {
             return null;
         }
-        const classList = this.$element._container.classList;
+        const classList = this.$element._container.children[0].classList;
         if (classList.contains('lg')) {
             return 'lg';
         } else if (classList.contains('md')) {

--- a/packages/ramp-core/src/api/panel-instance.ts
+++ b/packages/ramp-core/src/api/panel-instance.ts
@@ -1,4 +1,4 @@
-import Vue, { Component } from 'vue';
+import Vue, { Component, defineAsyncComponent } from 'vue';
 
 import {
     APIScope,
@@ -77,14 +77,13 @@ export class PanelInstance extends APIScope {
 
         if (isComponentOptions(screen) || isVueConstructor(screen)) {
             payload = screen;
-
             this.loadedScreens.push(id); // mark this screen immediately as loaded
         } else {
             let asyncComponent: Promise<AsyncComponentEh>;
 
             if (typeof screen === 'string') {
-                asyncComponent = import(
-                    /* webpackChunkName: "[request]" */ `./../../src/fixtures/${screen}`
+                asyncComponent = defineAsyncComponent(
+                    require(`./../../src/fixtures/${screen}`)
                 );
             } else {
                 asyncComponent = screen(); // execute the async component function to get the promise

--- a/packages/ramp-core/src/api/panel.ts
+++ b/packages/ramp-core/src/api/panel.ts
@@ -334,10 +334,9 @@ export class PanelAPI extends APIScope {
 
         // register all the panel screen components globally
         // only register if it hasn't been registered before
-        // TODO: fix this if needed
-        // if (!(route.screen in this.$vApp.$options.components!)) {
-        panel.registerScreen(route.screen);
-        // }
+        if (!(route.screen in this.$element._context.components!)) {
+            panel.registerScreen(route.screen);
+        }
 
         this.$vApp.$store.set(`panel/items@${panel.id}.route`, route);
 

--- a/packages/ramp-core/src/components/map/esri-map.vue
+++ b/packages/ramp-core/src/components/map/esri-map.vue
@@ -39,9 +39,9 @@ export default class EsriMapV extends Vue {
     layerConfigs: ComputedRef<RampLayerConfig[]> = get(LayerStore.layerConfigs);
     // @Get(LayerStore.layerConfigs) layerConfigs!: RampLayerConfig[];
 
-    maptipProperties: ComputedRef<any> = get(MaptipStore.maptipProperties);
+    maptipProperties: any = get(MaptipStore.maptipProperties);
     // @Get(MaptipStore.maptipProperties) maptipProperties!: any;
-    maptipInstance: ComputedRef<any> = get(MaptipStore.maptipInstance);
+    maptipInstance: any = get(MaptipStore.maptipInstance);
     // @Get(MaptipStore.maptipInstance) maptipInstance!: any;
 
     map!: MapAPI; // TODO assuming we need this as a local property for vue binding. if we don't, remove it and just use $iApi.geo.map
@@ -53,22 +53,22 @@ export default class EsriMapV extends Vue {
 
     @Watch('maptipProperties')
     onMaptipChange() {
-        if (this.maptipProperties.value) {
+        if (this.maptipProperties) {
             // Calculate offset from mappoint
             let offsetX, offsetY: number;
             const originX: number = this.$iApi.geo.map.getPixelWidth() / 2;
             const originY: number = 0;
             const screenPointFromMapPoint = this.$iApi.geo.map.mapPointToScreenPoint(
-                this.maptipProperties.value.mapPoint
+                this.maptipProperties.mapPoint
             );
             offsetX = screenPointFromMapPoint.screenX - originX;
             offsetY = originY - screenPointFromMapPoint.screenY;
-            this.maptipInstance.value.set({
+            this.maptipInstance.setProps({
                 offset: `${offsetX}, ${offsetY}`
             });
-            this.maptipInstance.value.show();
+            this.maptipInstance.show();
         } else {
-            this.maptipInstance.value.hide();
+            this.maptipInstance.hide();
         }
     }
 

--- a/packages/ramp-core/src/components/panel-stack/panel-container.vue
+++ b/packages/ramp-core/src/components/panel-stack/panel-container.vue
@@ -7,13 +7,7 @@
         <!-- this renders a panel screen which is currently in view -->
 
         <!-- only perform transition on screen components that are not loaded yet; if already loaded, switch right away -->
-        <transition
-            mode="out-in"
-            :css="false"
-            @before-leave="beforeLeave"
-            @leave="leave"
-            @enter="enter"
-        >
+        <transition @before-leave="beforeLeave" @leave="leave" @enter="enter">
             <component
                 :is="panel.route.screen"
                 v-bind="panel.route.props"

--- a/packages/ramp-core/src/components/panel-stack/panel-stack.vue
+++ b/packages/ramp-core/src/components/panel-stack/panel-stack.vue
@@ -66,7 +66,7 @@ export default class PanelStackV extends Vue {
 
     leave(el: HTMLElement, done: () => {}): void {
         const [bbox, pbbox] = [
-            el.getBoundingClientRect(),
+            el.children[0].getBoundingClientRect(),
             el.parentElement!.getBoundingClientRect()
         ];
 

--- a/packages/ramp-core/src/fixtures/details/item-screen.vue
+++ b/packages/ramp-core/src/fixtures/details/item-screen.vue
@@ -77,9 +77,7 @@ import HTMLDefaultV from './templates/html-default.vue';
     }
 })
 export default class DetailsItemScreenV extends Vue {
-    templateBindings: ComputedRef<{
-        [id: string]: DetailsItemInstance;
-    }> = get(DetailsStore.templates);
+    templateBindings: any = get(DetailsStore.templates);
     // @Get(DetailsStore.templates) templateBindings!: {
     //     [id: string]: DetailsItemInstance;
     // };
@@ -95,11 +93,9 @@ export default class DetailsItemScreenV extends Vue {
     @Prop() isFeature!: boolean;
 
     // retrieve the identify payload from the store
-    payload: ComputedRef<IdentifyResult[]> = get(DetailsStore.payload);
+    payload: any = get(DetailsStore.payload);
     // @Get(DetailsStore.payload) payload!: IdentifyResult[];
-    getLayerByUid: ComputedRef<
-        (uid: string) => LayerInstance | undefined
-    > = get('layer/getLayerByUid');
+    getLayerByUid: any = get('layer/getLayerByUid');
     // @Get('layer/getLayerByUid') getLayerByUid!: (
     //     uid: string
     // ) => LayerInstance | undefined;
@@ -117,13 +113,13 @@ export default class DetailsItemScreenV extends Vue {
      * Returns the information for a single identify result, given the layer and item offsets.
      */
     get identifyItem() {
-        return this.payload.value[this.resultIndex].items[this.itemIndex];
+        return this.payload[this.resultIndex].items[this.itemIndex];
     }
 
     get itemName() {
-        const layerInfo = this.payload.value[this.resultIndex];
+        const layerInfo = this.payload[this.resultIndex];
         const uid = layerInfo.uid;
-        const layer: LayerInstance | undefined = this.getLayerByUid.value(uid);
+        const layer: LayerInstance | undefined = this.getLayerByUid(uid);
         const nameField = layer?.getNameField(uid);
         return nameField
             ? this.identifyItem.data[nameField]
@@ -131,9 +127,9 @@ export default class DetailsItemScreenV extends Vue {
     }
 
     fetchIcon() {
-        const layerInfo = this.payload.value[this.resultIndex];
+        const layerInfo = this.payload[this.resultIndex];
         const uid = layerInfo.uid;
-        const layer: LayerInstance | undefined = this.getLayerByUid.value(uid);
+        const layer: LayerInstance | undefined = this.getLayerByUid(uid);
         if (layer === undefined) {
             console.warn(
                 `could not find layer for uid ${uid} during icon lookup`
@@ -147,8 +143,8 @@ export default class DetailsItemScreenV extends Vue {
     }
 
     get detailsTemplate() {
-        const layerInfo = this.payload.value[this.resultIndex];
-        const layer: LayerInstance | undefined = this.getLayerByUid.value(
+        const layerInfo = this.payload[this.resultIndex];
+        const layer: LayerInstance | undefined = this.getLayerByUid(
             layerInfo.uid
         );
 
@@ -156,10 +152,10 @@ export default class DetailsItemScreenV extends Vue {
         // return its name.
         if (
             layer &&
-            this.templateBindings.value[layer.id] &&
-            this.templateBindings.value[layer.id].componentId
+            this.templateBindings[layer.id] &&
+            this.templateBindings[layer.id].template
         ) {
-            return this.templateBindings.value[layer.id].componentId;
+            return this.templateBindings[layer.id].template;
         }
 
         // If nothing is found, use a default template.
@@ -171,9 +167,9 @@ export default class DetailsItemScreenV extends Vue {
     }
 
     zoomToFeature() {
-        const layerInfo = this.payload.value[this.resultIndex];
+        const layerInfo = this.payload[this.resultIndex];
         const uid = layerInfo.uid;
-        const layer: LayerInstance | undefined = this.getLayerByUid.value(uid);
+        const layer: LayerInstance | undefined = this.getLayerByUid(uid);
 
         if (layer === undefined) {
             console.warn(

--- a/packages/ramp-core/src/fixtures/details/layers-screen.vue
+++ b/packages/ramp-core/src/fixtures/details/layers-screen.vue
@@ -33,7 +33,6 @@
 </template>
 
 <script lang="ts">
-import { ComputedRef } from 'vue';
 import { Vue, Prop } from 'vue-property-decorator';
 import { Get } from 'vuex-pathify';
 import { get } from '@/store/pathify-helper';
@@ -44,15 +43,16 @@ import { IdentifyResult } from '@/geo/api';
 
 export default class DetailsLayersScreenV extends Vue {
     @Prop() panel!: PanelInstance;
-    payload: ComputedRef<IdentifyResult[]> = get(DetailsStore.payload);
+    payload: any = get(DetailsStore.payload);
+
     // @Get(DetailsStore.payload) payload!: IdentifyResult[];
-    getLayerByUid: ComputedRef<
-        (uid: string) => LayerInstance | undefined
-    > = get('layer/getLayerByUid');
+
+    getLayerByUid: any = get('layer/getLayerByUid');
+
     // @Get('layer/getLayerByUid') getLayerByUid!: (
     //     uid: string
     // ) => LayerInstance | undefined;
-    layers: ComputedRef<LayerInstance[]> = get('layer/layers');
+    layers: LayerInstance[] = <LayerInstance[]>(<unknown>get('layer/layers'));
     // @Get('layer/layers') layers!: LayerInstance[];
 
     /**
@@ -60,8 +60,7 @@ export default class DetailsLayersScreenV extends Vue {
      */
     openResult(index: number) {
         if (
-            this.getLayerByUid.value(this.payload.value[index].uid)!
-                .layerType === 'ogcWms'
+            this.getLayerByUid(this.payload[index].uid)!.layerType === 'ogcWms'
         ) {
             // skip results screen for wms layers
             this.panel.show({
@@ -77,10 +76,9 @@ export default class DetailsLayersScreenV extends Vue {
     }
 
     layerInfo(idx: number) {
-        const layerInfo = this.payload.value[idx];
-
+        const layerInfo = this.payload[idx];
         // Check to see if there is a custom template defined for the selected layer.
-        let item: LayerInstance | undefined = this.layers.value
+        let item: LayerInstance | undefined = this.layers
             .map(layer => {
                 let layerNode = layer.getLayerTree();
 
@@ -102,9 +100,9 @@ export default class DetailsLayersScreenV extends Vue {
      * Calculates the total number of results received by identify.
      */
     get payloadResults(): number {
-        return this.payload.value
-            .map(r => r.items.length)
-            .reduce((a, b) => a + b, 0);
+        return this.payload
+            .map((r: IdentifyResult) => r.items.length)
+            .reduce((a: number, b: number) => a + b, 0);
     }
 }
 </script>

--- a/packages/ramp-core/src/fixtures/details/result-screen.vue
+++ b/packages/ramp-core/src/fixtures/details/result-screen.vue
@@ -1,8 +1,6 @@
 <template>
     <panel-screen :panel="panel">
-        <template #header>
-            {{ $t('details.title') }}
-        </template>
+        <template #header>{{ $t('details.title') }}</template>
         <template #controls>
             <minimize @click="panel.minimize()"></minimize>
             <back @click="panel.show('details-screen-layers')"></back>
@@ -50,11 +48,9 @@ export default class DetailsResultScreenV extends Vue {
     @Prop() panel!: PanelInstance;
     @Prop() resultIndex!: number;
 
-    payload: ComputedRef<IdentifyResult[]> = get(DetailsStore.payload);
+    payload: any = get(DetailsStore.payload);
     // @Get(DetailsStore.payload) payload!: IdentifyResult[];
-    getLayerByUid: ComputedRef<
-        (uid: string) => LayerInstance | undefined
-    > = get('layer/getLayerByUid');
+    getLayerByUid: any = get('layer/getLayerByUid');
     // @Get('layer/getLayerByUid') getLayerByUid!: (
     //     uid: string
     // ) => LayerInstance | undefined;
@@ -79,7 +75,7 @@ export default class DetailsResultScreenV extends Vue {
      */
     itemIcon(data: any, idx: number) {
         const uid = this.identifyResult.uid;
-        const layer: LayerInstance | undefined = this.getLayerByUid.value(uid);
+        const layer: LayerInstance | undefined = this.getLayerByUid(uid);
         if (layer === undefined) {
             console.warn(
                 `could not find layer for uid ${uid} during icon lookup`
@@ -101,16 +97,16 @@ export default class DetailsResultScreenV extends Vue {
      * Returns the identify information for the layer specified by resultIndex.
      */
     get identifyResult() {
-        return this.payload.value[this.resultIndex];
+        return this.payload[this.resultIndex];
     }
 
     /**
      * Returns the name field for the layer specified by resultIndex.
      */
     get nameField() {
-        const layerInfo = this.payload.value[this.resultIndex];
+        const layerInfo = this.payload[this.resultIndex];
         const uid = layerInfo?.uid;
-        const layer: LayerInstance | undefined = this.getLayerByUid.value(uid);
+        const layer: LayerInstance | undefined = this.getLayerByUid(uid);
         return layer?.getNameField(uid);
     }
 }

--- a/packages/ramp-core/src/geo/map/ramp-map.ts
+++ b/packages/ramp-core/src/geo/map/ramp-map.ts
@@ -891,8 +891,6 @@ export class MapAPI extends CommonMapAPI {
             mapClick = payload;
         }
 
-        console.log('Results', identifyResults);
-
         // TODO make the event payload an interface? should there be a public area with all event payload interfaces?
         this.$iApi.event.emit(GlobalEvents.MAP_IDENTIFY, {
             results: identifyResults,


### PR DESCRIPTION
Changes in this PR:
- the details panel now opens and you can navigate between the screens
- panels will now appear beside each other instead of overlapping
- the map tooltips will no longer cause the app to crash. They still don't appear on the map for some reason, could be tippy related.


You can find a demo for this PR [here](http://ramp4-app.azureedge.net/demo/users/RyanCoulsonCA/vue3-details-fix/host/index.html).


Notes:
- had to remove `mode: "out-in"` from the panel transition element. It's causing the panel rendering to break with no error.
- I had to change some types in the details screen fixtures to `any` in order to index the arrays properly. Not sure about a good workaround for this at the moment.
- the feature counter on the layers screen isn't updating on first render. Not sure what's causing this, but I'll come back to it later to investigate more.
- Unable to fully test custom details templates: it looks like it is trying to render the component, but they've [changed the way the `h` render function works](https://v3.vuejs.org/guide/migration/render-function-api.html#_2-x-syntax). You now need to import h from Vue, which I don't think we can do from the host page. We need to look into a way to get this working, or we can enable the runtime compiler. I did try to do this but was running into some issues so I didn't include it in this PR.

*UPDATE FOR THE LAST POINT: custom details templates seem to work in the actual build but not locally, so this isn't as much of a concern to me anymore. Obviously, it would be nice to get it working in local builds eventually but we can push it back a bit.*