### PR TITLE
fix geosearch fixture + conversion to defineComponent

### DIFF
--- a/packages/ramp-core/src/fixtures/basemap/item.vue
+++ b/packages/ramp-core/src/fixtures/basemap/item.vue
@@ -82,13 +82,9 @@ export default defineComponent({
     props: ['basemap', 'tileSchema'],
     data() {
         return {
-            selectedBasemap: get(BasemapStore.selectedBasemap)
+            selectedBasemap: get(BasemapStore.selectedBasemap),
+            selectBasemap: call(BasemapStore.selectBasemap)
         };
-    },
-    methods: {
-        selectBasemap(basemap: RampBasemapConfig) {
-            call(BasemapStore.selectBasemap, basemap);
-        }
     }
 });
 </script>

--- a/packages/ramp-core/src/fixtures/geosearch/loading-bar.vue
+++ b/packages/ramp-core/src/fixtures/geosearch/loading-bar.vue
@@ -13,9 +13,11 @@
 </template>
 
 <script>
-import { Vue } from 'vue-property-decorator';
+import { defineComponent } from 'vue';
 
-export default class GeosearchLoadingBarV extends Vue {}
+export default defineComponent({
+    name: 'GeosearchLoadingBarV'
+});
 </script>
 
 <style scoped>

--- a/packages/ramp-core/src/fixtures/geosearch/screen.vue
+++ b/packages/ramp-core/src/fixtures/geosearch/screen.vue
@@ -4,15 +4,8 @@
             <geosearch-bar></geosearch-bar>
         </template>
         <template #controls>
-            <pin
-                @click="panel.pin()"
-                :active="isPinned"
-                v-if="$iApi.screenSize !== 'xs'"
-            ></pin>
-            <close
-                @click="panel.close()"
-                v-if="$iApi.screenSize !== 'xs'"
-            ></close>
+            <pin @click="panel.pin()" :active="isPinned" v-if="$iApi.screenSize !== 'xs'"></pin>
+            <close @click="panel.close()" v-if="$iApi.screenSize !== 'xs'"></close>
         </template>
 
         <template #content>
@@ -25,15 +18,9 @@
                 <div class="px-5 mb-10 truncate">
                     <span
                         class="relative h-48"
-                        v-if="
-                            searchVal &&
-                                searchResults.length === 0 &&
-                                !loadingResults
-                        "
+                        v-if="searchVal && searchResults.length === 0 && !loadingResults"
                         >{{ $t('geosearch.noResults')
-                        }}<span class="font-bold text-blue-600"
-                            >"{{ searchVal }}"</span
-                        ></span
+                        }}<span class="font-bold text-blue-600">"{{ searchVal }}"</span></span
                     >
                 </div>
                 <ul
@@ -51,10 +38,7 @@
                             @click="zoomIn(result)"
                             v-focus-item="'show-truncate'"
                         >
-                            <div
-                                class="rv-result-description flex px-8"
-                                v-truncate
-                            >
+                            <div class="rv-result-description flex px-8" v-truncate>
                                 <div class="flex-1 text-left truncate">
                                     <span
                                         v-html="
@@ -87,18 +71,14 @@
                         </button>
                     </li>
                 </ul>
-                <geosearch-bottom-filters
-                    class="mt-auto"
-                ></geosearch-bottom-filters>
+                <geosearch-bottom-filters class="mt-auto"></geosearch-bottom-filters>
             </div>
         </template>
     </panel-screen>
 </template>
 
 <script lang="ts">
-import { ComputedRef } from 'vue';
-import { Vue, Options, Prop } from 'vue-property-decorator';
-import { Get } from 'vuex-pathify';
+import { defineComponent } from 'vue';
 import { get } from '@/store/pathify-helper';
 import { PanelInstance } from '@/api';
 
@@ -109,46 +89,51 @@ import GeosearchTopFiltersV from './top-filters.vue';
 import GeosearchBottomFiltersV from './bottom-filters.vue';
 import GeosearchLoadingBarV from './loading-bar.vue';
 
-@Options({
+export default defineComponent({
+    name: 'GeosearchScreenV',
+
+    props: ['panel'],
+
+    // Import required components.
     components: {
         'geosearch-bar': GeosearchSearchBarV,
         'geosearch-top-filters': GeosearchTopFiltersV,
         'geosearch-bottom-filters': GeosearchBottomFiltersV,
         'loading-bar': GeosearchLoadingBarV
-    }
-})
-export default class GeosearchScreenV extends Vue {
-    @Prop() panel!: PanelInstance;
+    },
+
     // fetch store properties/data
-    searchVal: ComputedRef<string> = get(GeosearchStore.searchVal);
-    searchResults: ComputedRef<Array<any>> = get(GeosearchStore.searchResults);
-    loadingResults: ComputedRef<boolean> = get(GeosearchStore.loadingResults);
-    // @Get(GeosearchStore.searchVal) searchVal!: string;
-    // @Get(GeosearchStore.searchResults) searchResults!: Array<any>;
-    // @Get(GeosearchStore.loadingResults) loadingResults!: boolean;
+    data() {
+        return {
+            searchVal: get(GeosearchStore.searchVal),
+            searchResults: get(GeosearchStore.searchResults),
+            loadingResults: get(GeosearchStore.loadingResults)
+        };
+    },
 
-    get isPinned(): boolean {
-        return this.panel.isPinned;
-    }
+    methods: {
+        isPinned(): boolean {
+            return this.panel.isPinned;
+        },
 
-    // zoom in to a clicked result
-    zoomIn(result: any): void {
-        let zoomPoint = new RAMP.GEO.Point('zoomies', result.position);
-        this.$iApi.geo.map.zoomMapTo(zoomPoint, 50000);
-    }
+        // zoom in to a clicked result
+        zoomIn(result: any): void {
+            let zoomPoint = new RAMP.GEO.Point('zoomies', result.position);
+            this.$iApi.geo.map.zoomMapTo(zoomPoint, 50000);
+        },
 
-    // highlight the search term in each listed geosearch result
-    highlightSearchTerm(name: string, province: any) {
-        // wrap matched search term in results inside span with styling
-        const highlightedResult = name.replace(
-            new RegExp(`${this.searchVal.value}`, 'gi'),
-            match =>
-                '<span class="font-bold text-blue-600">' + match + '</span>'
-        );
-        // add comma to new highlighted result if a province/location is provided
-        return province ? highlightedResult + ',' : highlightedResult;
+        // highlight the search term in each listed geosearch result
+        highlightSearchTerm(name: string, province: any) {
+            // wrap matched search term in results inside span with styling
+            const highlightedResult = name.replace(
+                new RegExp(`${this.searchVal.value}`, 'gi'),
+                match => '<span class="font-bold text-blue-600">' + match + '</span>'
+            );
+            // add comma to new highlighted result if a province/location is provided
+            return province ? highlightedResult + ',' : highlightedResult;
+        }
     }
-}
+});
 </script>
 
 <style lang="scss" scoped></style>

--- a/packages/ramp-core/src/fixtures/geosearch/search-bar.vue
+++ b/packages/ramp-core/src/fixtures/geosearch/search-bar.vue
@@ -11,29 +11,27 @@
 </template>
 
 <script lang="ts">
-import { ComputedRef } from 'vue';
+import { defineComponent } from 'vue';
 import { Vue } from 'vue-property-decorator';
 import { Get, Call } from 'vuex-pathify';
-import { get } from '@/store/pathify-helper';
-
+import { get, call } from '@/store/pathify-helper';
 import { GeosearchStore } from './store';
 import { debounce } from 'throttle-debounce';
 
-export default class GeosearchSearchBarV extends Vue {
-    // fetch geosearch search value from store
-    searchVal: ComputedRef<string> = get(GeosearchStore.searchVal);
-    // @Get(GeosearchStore.searchVal) searchVal!: string;
+export default defineComponent({
+    data() {
+        return {
+            // fetch search value and actions from store
+            searchVal: get(GeosearchStore.searchVal),
+            setSearchTerm: call(GeosearchStore.setSearchTerm),
 
-    // import required geosearch actions
-    @Call(GeosearchStore.setSearchTerm) setSearchTerm!: (
-        searchTerm: string
-    ) => void;
-
-    // debounce function for search term change
-    onSearchTermChange = debounce(500, (searchTerm: string) => {
-        this.setSearchTerm(searchTerm);
-    });
-}
+            // debounce function for search term change
+            onSearchTermChange: debounce(500, (searchTerm: string) => {
+                this.setSearchTerm(searchTerm);
+            })
+        };
+    }
+});
 </script>
 
 <style lang="scss" scoped></style>

--- a/packages/ramp-core/src/fixtures/geosearch/store/geosearch-store.ts
+++ b/packages/ramp-core/src/fixtures/geosearch/store/geosearch-store.ts
@@ -19,9 +19,7 @@ const getters = {
     getProvinces: (state: GeosearchState): [] => {
         const provs = state.GSservice.fetchProvinces();
         // sort the province filters in alphabetical order
-        provs.sort((provA: any, provB: any) =>
-            provA.name > provB.name ? 1 : -1
-        );
+        provs.sort((provA: any, provB: any) => (provA.name > provB.name ? 1 : -1));
         return provs;
     },
 
@@ -36,9 +34,7 @@ const getters = {
     getTypes: (state: GeosearchState): [] => {
         const types = state.GSservice.fetchTypes();
         // sort the type filters in alphabetical order
-        types.sort((typeA: any, typeB: any) =>
-            typeA.name > typeB.name ? 1 : -1
-        );
+        types.sort((typeA: any, typeB: any) => (typeA.name > typeB.name ? 1 : -1));
         return types;
     }
 };
@@ -75,14 +71,9 @@ const actions = {
                 context.state.searchVal &&
                 context.state.searchVal !== context.state.lastSearchVal
             ) {
-                context.state.GSservice.query(
-                    `${context.state.searchVal}*`
-                ).then((data: any) => {
+                context.state.GSservice.query(`${context.state.searchVal}*`).then((data: any) => {
                     // store data for current search term
-                    context.commit(
-                        'SET_LAST_SEARCH_VAL',
-                        context.state.searchVal
-                    );
+                    context.commit('SET_LAST_SEARCH_VAL', context.state.searchVal);
                     context.commit('SET_SAVED_RESULTS', data);
 
                     // replace old saved results
@@ -113,10 +104,7 @@ const actions = {
      * @param   {string}    province   the province code all results must be in
      */
     setProvince: function(context: GeosearchContext, province: string): void {
-        context.commit(
-            'SET_PROVINCE',
-            typeof province === 'undefined' ? '' : province
-        );
+        context.commit('SET_PROVINCE', typeof province === 'undefined' ? '' : province);
         // run query after province filter changes
         context.dispatch('runQuery');
     },
@@ -192,9 +180,7 @@ function filter(visibleOnly: boolean, queryParams: any, data: Array<any>) {
     }
     if (queryParams.province && queryParams.province !== '...') {
         data = data.filter(
-            r =>
-                r.location.province.name &&
-                r.location.province.name === queryParams.province
+            r => r.location.province.name && r.location.province.name === queryParams.province
         );
     }
     if (queryParams.type && queryParams.type !== '...') {

--- a/packages/ramp-core/src/fixtures/geosearch/top-filters.vue
+++ b/packages/ramp-core/src/fixtures/geosearch/top-filters.vue
@@ -6,13 +6,8 @@
                 :value="queryParams.province"
                 v-on:change="setProvince($event.target.value)"
             >
-                <option value="" disabled hidden>{{
-                    $t('geosearch.filters.province')
-                }}</option>
-                <option
-                    v-for="province in provinces"
-                    v-bind:key="province.code"
-                >
+                <option value="" disabled hidden>{{ $t('geosearch.filters.province') }}</option>
+                <option v-for="province in provinces" v-bind:key="province.code">
                     {{ province.name }}
                 </option>
             </select>
@@ -23,9 +18,7 @@
                 :value="queryParams.type"
                 v-on:change="setType($event.target.value)"
             >
-                <option value="" disabled hidden>{{
-                    $t('geosearch.filters.type')
-                }}</option>
+                <option value="" disabled hidden>{{ $t('geosearch.filters.type') }}</option>
                 <option v-for="type in types" v-bind:key="type.code">
                     {{ type.name }}
                 </option>
@@ -50,32 +43,31 @@
 </template>
 
 <script lang="ts">
-import { ComputedRef } from 'vue';
-import { Vue } from 'vue-property-decorator';
-import { Get, Call } from 'vuex-pathify';
-import { get } from '@/store/pathify-helper';
-
+import { defineComponent } from 'vue';
+import { get, call } from '@/store/pathify-helper';
 import { GeosearchStore } from './store';
 
-export default class GeosearchTopFiltersV extends Vue {
+export default defineComponent({
+    name: 'GeosearchTopFiltersV',
+
     // fetch defined province/type filters + filter params from store
-    provinces: ComputedRef<Array<any>> = get(GeosearchStore.getProvinces);
-    types: ComputedRef<Array<any>> = get(GeosearchStore.getTypes);
-    queryParams: ComputedRef<any> = get(GeosearchStore.queryParams);
-    // @Get(GeosearchStore.getProvinces) provinces!: Array<any>;
-    // @Get(GeosearchStore.getTypes) types!: Array<any>;
-    // @Get(GeosearchStore.queryParams) queryParams!: any;
-
-    // import required geosearch store actions
-    @Call(GeosearchStore.setProvince) setProvince!: (prov: any) => void;
-    @Call(GeosearchStore.setType) setType!: (type: any) => void;
-
-    // clear filters by setting filters to undefined
-    clearFilters(): void {
-        this.setProvince(undefined);
-        this.setType(undefined);
+    data() {
+        return {
+            provinces: get(GeosearchStore.getProvinces),
+            types: get(GeosearchStore.getTypes),
+            queryParams: get(GeosearchStore.queryParams),
+            setProvince: call(GeosearchStore.setProvince),
+            setType: call(GeosearchStore.setType)
+        };
+    },
+    methods: {
+        // Called when the `clear filters` button is clicked. Clears province and type filters.
+        clearFilters(): void {
+            this.setProvince(undefined);
+            this.setType(undefined);
+        }
     }
-}
+});
 </script>
 
 <style lang="scss" scoped></style>

--- a/packages/ramp-core/src/store/pathify-helper.js
+++ b/packages/ramp-core/src/store/pathify-helper.js
@@ -23,6 +23,6 @@ export function sync(path) {
     });
 }
 
-export function call(path, payload) {
-    return store.dispatch(path, payload);
+export function call(path) {
+    return payload => computed(store.dispatch(path, payload));
 }


### PR DESCRIPTION
**Changes in this PR**
- the geosearch fixture now works as expected
- changed all of the geosearch components to use the Vue 3 `defineComponent` function in order to help out with the Composition API migration
- fixed the vuex-pathify `call` helper: it needed to return a function instead of directly calling dispatch


**Concerns**
Converting the fixture screen (screen.vue) to the composition API brings up a new warning in console: 

> Vue received a Component which was made a reactive object. This can lead to unnecessary performance overhead, and should be avoided by marking the component with `markRaw` or using `shallowRef` instead of `ref`. 

It looks like this comes from us [storing the component in Vuex](https://forum.vuejs.org/t/vue-received-a-component-which-was-made-a-reactive-object/119004) (the panel store, I believe). Not sure how to get around this at the moment, but we may need to make some changes to the panel API in the future.


**Testing**

You can find a demo for this PR [here](http://ramp4-app.azureedge.net/demo/users/RyanCoulsonCA/vue3-fix-geosearch/host/index.html).

- Click on the Geosearch fixture on the appbar (magnifying glass icon)
- Play around with it. Enter some keyboards (lake, road, etc.) and make sure that results update correctly.
- Click on the 'Visible on Map' button at the bottom of the fixture, zoom in/pan to different parts of Canada and make sure the results update.