### PR TITLE
fix panel events firing twice

### DIFF
--- a/packages/ramp-core/src/api/panel-instance.ts
+++ b/packages/ramp-core/src/api/panel-instance.ts
@@ -82,9 +82,7 @@ export class PanelInstance extends APIScope {
             let asyncComponent: Promise<AsyncComponentEh>;
 
             if (typeof screen === 'string') {
-                asyncComponent = defineAsyncComponent(
-                    require(`./../../src/fixtures/${screen}`)
-                );
+                asyncComponent = defineAsyncComponent(require(`./../../src/fixtures/${screen}`));
             } else {
                 asyncComponent = screen(); // execute the async component function to get the promise
             }
@@ -268,9 +266,7 @@ export class PanelInstance extends APIScope {
      * @returns {this}
      * @memberof PanelInstance
      */
-    toggle(
-        value?: boolean | { screen: string; props?: object; toggle?: boolean }
-    ): this {
+    toggle(value?: boolean | { screen: string; props?: object; toggle?: boolean }): this {
         // toggle panel if no value provided, force toggle panel if value specified, or toggle panel on specified screen if provided
         // ensure that a toggle value must be provided to panel API toggle if called
         if (typeof value === 'undefined') {
@@ -283,9 +279,7 @@ export class PanelInstance extends APIScope {
         } else {
             this.$iApi.panel.toggle(
                 { id: this.id, screen: value.screen, props: value.props },
-                typeof value.toggle !== 'undefined'
-                    ? value.toggle
-                    : !this.isOpen
+                typeof value.toggle !== 'undefined' ? value.toggle : !this.isOpen
             );
         }
 
@@ -300,9 +294,7 @@ export class PanelInstance extends APIScope {
      * @returns {this}
      * @memberof PanelInstance
      */
-    toggleMinimize(
-        value?: boolean | { screen: string; props?: object; toggle?: boolean }
-    ): this {
+    toggleMinimize(value?: boolean | { screen: string; props?: object; toggle?: boolean }): this {
         if (typeof value === 'undefined' || typeof value === 'boolean') {
             // value is a toggle so we pass it through
             this.$iApi.panel.toggleMinimize(this, value);
@@ -310,9 +302,7 @@ export class PanelInstance extends APIScope {
             // value is not a toggle, split into what panel.toggleMinimize is expecting
             this.$iApi.panel.toggleMinimize(
                 { id: this.id, screen: value.screen, props: value.props },
-                typeof value.toggle !== 'undefined'
-                    ? value.toggle
-                    : !this.isOpen
+                typeof value.toggle !== 'undefined' ? value.toggle : !this.isOpen
             );
         }
 
@@ -346,10 +336,7 @@ export class PanelInstance extends APIScope {
      * @memberof PanelInstance
      */
     get isPinned(): boolean {
-        return (
-            this.$iApi.panel.pinned !== null &&
-            this.$iApi.panel.pinned.id === this.id
-        );
+        return this.$iApi.panel.pinned !== null && this.$iApi.panel.pinned.id === this.id;
     }
 
     /**

--- a/packages/ramp-core/src/api/panel.ts
+++ b/packages/ramp-core/src/api/panel.ts
@@ -1,10 +1,5 @@
 import { APIScope, GlobalEvents, PanelInstance } from './internal';
-import {
-    PanelConfig,
-    PanelConfigRoute,
-    PanelMutation,
-    PanelAction
-} from '@/store/modules/panel';
+import { PanelConfig, PanelConfigRoute, PanelMutation, PanelAction } from '@/store/modules/panel';
 
 import { I18nComponentOptions } from '@/lang';
 
@@ -18,10 +13,7 @@ export class PanelAPI extends APIScope {
      * @returns {PanelInstance}
      * @memberof PanelAPI
      */
-    register(
-        value: PanelConfigPair,
-        options?: PanelRegistrationOptions
-    ): PanelInstance;
+    register(value: PanelConfigPair, options?: PanelRegistrationOptions): PanelInstance;
     /**
      * Registers a set of provided panel objects and returns the resulting `PanelInstance` object set.
      * When the panel is registered, all its screens are added to the Vue as components right away.
@@ -31,17 +23,12 @@ export class PanelAPI extends APIScope {
      * @returns {PanelInstanceSet}
      * @memberof PanelAPI
      */
-    register(
-        value: PanelConfigSet,
-        options?: PanelRegistrationOptions
-    ): PanelInstanceSet;
+    register(value: PanelConfigSet, options?: PanelRegistrationOptions): PanelInstanceSet;
     register(
         value: PanelConfigPair | PanelConfigSet,
         options?: PanelRegistrationOptions
     ): PanelInstance | PanelInstanceSet {
-        const panelConfigs = isPanelConfigPair(value)
-            ? { [value.id]: value.config }
-            : value;
+        const panelConfigs = isPanelConfigPair(value) ? { [value.id]: value.config } : value;
 
         if (options) {
             const i18n = options.i18n || {};
@@ -62,12 +49,13 @@ export class PanelAPI extends APIScope {
 
         // TODO: check if the panel with the same id already exist and don't create a new one
         // create panel instances
-        const panels: PanelInstance[] = Object.entries(panelConfigs).reduce<
-            PanelInstance[]
-        >((map, [id, config]) => {
-            map.push(new PanelInstance(this.$iApi, id, config));
-            return map;
-        }, []);
+        const panels: PanelInstance[] = Object.entries(panelConfigs).reduce<PanelInstance[]>(
+            (map, [id, config]) => {
+                map.push(new PanelInstance(this.$iApi, id, config));
+                return map;
+            },
+            []
+        );
 
         // register all the panels with the store
         panels.forEach(panel =>
@@ -119,9 +107,7 @@ export class PanelAPI extends APIScope {
      * @memberof PanelAPI
      */
     open(value: string | PanelInstance | PanelInstancePath): PanelInstance {
-        let panel: PanelInstance,
-            screen: string | undefined,
-            props: object | undefined;
+        let panel: PanelInstance, screen: string | undefined, props: object | undefined;
 
         // figure out what is passed to the function and retrieve the panel object
         if (typeof value === 'string' || value instanceof PanelInstance) {
@@ -227,10 +213,7 @@ export class PanelAPI extends APIScope {
      * @returns {PanelInstance}
      * @memberof PanelAPI
      */
-    toggle(
-        value: string | PanelInstance | PanelInstancePath,
-        toggle?: boolean
-    ): PanelInstance {
+    toggle(value: string | PanelInstance | PanelInstancePath, toggle?: boolean): PanelInstance {
         let panel: PanelInstance;
 
         // figure out what is passed to the function, retrieve the panel object and make call to open or close function
@@ -326,10 +309,7 @@ export class PanelAPI extends APIScope {
      * @memberof PanelAPI
      */
     // TODO: implement panel route history
-    show(
-        value: string | PanelInstance,
-        route: PanelConfigRoute
-    ): PanelInstance {
+    show(value: string | PanelInstance, route: PanelConfigRoute): PanelInstance {
         const panel = this.get(value);
 
         // register all the panel screen components globally
@@ -374,14 +354,8 @@ export class PanelAPI extends APIScope {
  * @param {(PanelConfigPair | PanelConfigSet)} value
  * @returns {value is PanelConfigPair}
  */
-function isPanelConfigPair(
-    value: PanelConfigPair | PanelConfigSet
-): value is PanelConfigPair {
-    return (
-        value.id !== undefined &&
-        typeof value.id === 'string' &&
-        value.config !== undefined
-    );
+function isPanelConfigPair(value: PanelConfigPair | PanelConfigSet): value is PanelConfigPair {
+    return value.id !== undefined && typeof value.id === 'string' && value.config !== undefined;
 }
 
 /**

--- a/packages/ramp-core/src/components/panel-stack/controls/back.vue
+++ b/packages/ramp-core/src/components/panel-stack/controls/back.vue
@@ -3,7 +3,6 @@
         <button
             class="text-gray-500 hover:text-black p-8"
             :class="{ 'text-gray-700': active }"
-            @click="$emit('click')"
             :content="$t('panels.controls.back')"
             v-tippy="{ placement: 'bottom' }"
         >

--- a/packages/ramp-core/src/components/panel-stack/controls/close.vue
+++ b/packages/ramp-core/src/components/panel-stack/controls/close.vue
@@ -3,7 +3,6 @@
         <button
             class="text-gray-500 hover:text-black p-8"
             :class="{ 'text-gray-700': active }"
-            @click="$emit('click')"
             :content="$t('panels.controls.close')"
             v-tippy="{ placement: 'bottom' }"
         >

--- a/packages/ramp-core/src/components/panel-stack/controls/minimize.vue
+++ b/packages/ramp-core/src/components/panel-stack/controls/minimize.vue
@@ -3,7 +3,6 @@
         <button
             class="text-gray-500 hover:text-black p-6"
             :class="{ 'text-gray-700': active }"
-            @click="$emit('click')"
             :content="$t('panels.controls.minimize')"
             v-tippy="{ placement: 'bottom' }"
         >

--- a/packages/ramp-core/src/components/panel-stack/controls/pin.vue
+++ b/packages/ramp-core/src/components/panel-stack/controls/pin.vue
@@ -3,14 +3,7 @@
         <button
             class="text-gray-500 hover:text-black p-8"
             :class="{ 'text-gray-700': active }"
-            @click="$emit('click')"
-            :content="
-                $t(
-                    this.active
-                        ? 'panels.controls.unpin'
-                        : 'panels.controls.pin'
-                )
-            "
+            :content="$t(this.active ? 'panels.controls.unpin' : 'panels.controls.pin')"
             v-tippy="{ placement: 'bottom', hideOnClick: false }"
         >
             <svg

--- a/packages/ramp-core/src/fixtures/geosearch/screen.vue
+++ b/packages/ramp-core/src/fixtures/geosearch/screen.vue
@@ -3,8 +3,13 @@
         <template #header>
             <geosearch-bar></geosearch-bar>
         </template>
+
         <template #controls>
-            <pin @click="panel.pin()" :active="isPinned" v-if="$iApi.screenSize !== 'xs'"></pin>
+            <pin
+                @click="panel.pin()"
+                :active="panel.isPinned"
+                v-if="$iApi.screenSize !== 'xs'"
+            ></pin>
             <close @click="panel.close()" v-if="$iApi.screenSize !== 'xs'"></close>
         </template>
 
@@ -110,12 +115,7 @@ export default defineComponent({
             loadingResults: get(GeosearchStore.loadingResults)
         };
     },
-
     methods: {
-        isPinned(): boolean {
-            return this.panel.isPinned;
-        },
-
         // zoom in to a clicked result
         zoomIn(result: any): void {
             let zoomPoint = new RAMP.GEO.Point('zoomies', result.position);

--- a/packages/ramp-core/src/fixtures/legend/screen.vue
+++ b/packages/ramp-core/src/fixtures/legend/screen.vue
@@ -43,9 +43,7 @@ import LegendComponentV from './components/component.vue';
 export default class LegendScreenV extends Vue {
     @Prop() panel!: PanelInstance;
     // fetch store properties/data
-    children: ComputedRef<Array<LegendEntry | LegendGroup>> = get(
-        LegendStore.children
-    );
+    children: ComputedRef<Array<LegendEntry | LegendGroup>> = get(LegendStore.children);
     // @Get(LegendStore.children) children!: Array<LegendEntry | LegendGroup>;
 
     get isPinned(): boolean {


### PR DESCRIPTION
**Changes in this PR**
The way component events work in Vue 3 has changed from Vue 2 (you can read more [here](https://v3.vuejs.org/guide/migration/emits-option.html#migration-strategy) if interested).

This resulted in all of the panel events (pin, close, etc) firing twice. Event listeners are now included on root components, so the extra `$emit` call is no longer needed.

**Concerns**
~~The pin icon for the Geosearch fixture doesn't seem to be updating. It's not related to this PR though, I've confirmed that the `pinned` value is being updated. Just the icon isn't updating, possibly related to the custom header being used.~~

Solved the problem above.

**Testing**
You can find a demo for this PR [here](http://ramp4-app.azureedge.net/demo/users/RyanCoulsonCA/vue3-panel-pin-fix/host/index.html#).

To test, just open a panel and click the pin button. The icon should be updated properly now.