### PR TITLE
some tippy fixes + maptip fix

### DIFF
--- a/packages/ramp-core/src/app.vue
+++ b/packages/ramp-core/src/app.vue
@@ -33,7 +33,8 @@ export default class App extends Vue {
                 content: 'labelledby'
             },
             // a11y: false, // can't find a replacement for Vue 3
-            theme: 'ramp',
+            theme: 'ramp4',
+            inertia: true,
             trigger: 'mouseenter manual focus',
             // needed to have tooltips in fullscreen, by default it appends to document.body
             appendTo: this.$el
@@ -53,8 +54,7 @@ export default class App extends Vue {
 }
 .symbologyIcon {
     @apply bg-white inline-flex justify-center items-center overflow-hidden;
-    box-shadow: 0px 1px 3px 0px rgba(0, 0, 0, 0.2),
-        0px 1px 1px 0px rgba(0, 0, 0, 0.14),
+    box-shadow: 0px 1px 3px 0px rgba(0, 0, 0, 0.2), 0px 1px 1px 0px rgba(0, 0, 0, 0.14),
         0px 2px 1px -1px rgba(0, 0, 0, 0.12);
 }
 </style>

--- a/packages/ramp-core/src/components/controls/dropdown-menu.vue
+++ b/packages/ramp-core/src/components/controls/dropdown-menu.vue
@@ -52,10 +52,7 @@ export default class DropdownMenuV extends Vue {
         window.addEventListener(
             'click',
             event => {
-                if (
-                    event.target instanceof HTMLElement &&
-                    !this.$el.contains(event.target)
-                ) {
+                if (event.target instanceof HTMLElement && !this.$el.contains(event.target)) {
                     this.open = false;
                 }
             },
@@ -86,10 +83,7 @@ export default class DropdownMenuV extends Vue {
         window.removeEventListener(
             'click',
             event => {
-                if (
-                    event.target instanceof HTMLElement &&
-                    !this.$el.contains(event.target)
-                ) {
+                if (event.target instanceof HTMLElement && !this.$el.contains(event.target)) {
                     this.open = false;
                 }
             },

--- a/packages/ramp-core/src/components/map/map-caption.vue
+++ b/packages/ramp-core/src/components/map/map-caption.vue
@@ -14,10 +14,7 @@
             py-2
         "
     >
-        <span
-            class="relative ml-10 truncate top-1"
-            v-if="!attribution.logo.disabled"
-        >
+        <span class="relative ml-10 truncate top-1" v-if="!attribution.logo.disabled">
             <a
                 class="pointer-events-auto cursor-pointer"
                 :href="attribution.logo.link"
@@ -31,16 +28,11 @@
             </a>
         </span>
 
-        <span
-            class="relative ml-10 truncate top-1"
-            v-if="!attribution.text.disabled"
-        >
+        <span class="relative ml-10 truncate top-1" v-if="!attribution.text.disabled">
             {{ attribution.text.value }}
         </span>
 
-        <notifications-caption-button
-            class="sm:block hidden"
-        ></notifications-caption-button>
+        <notifications-caption-button class="sm:block hidden"></notifications-caption-button>
 
         <span class="flex-grow w-15"></span>
 

--- a/packages/ramp-core/src/directives/truncate/truncate.ts
+++ b/packages/ramp-core/src/directives/truncate/truncate.ts
@@ -34,6 +34,7 @@ export const Truncate: Directive = {
             // el.closest gets closes ancestor that maches the selector (moves up the parent chain)
             triggerElement = el.closest(`[${TRIGGER_ATTR}]`);
         }
+
         useTippy(el, {
             content: <TippyContent>el.textContent,
             onShow: onShow,
@@ -44,15 +45,17 @@ export const Truncate: Directive = {
             triggerTarget: triggerElement
         });
 
-        if (binding.value && binding.value.options) {
-            (el as any)._tippy.set(binding.value.options);
-        }
+        // if (binding.value && binding.value.options) {
+        //     (el as any)._tippy.set(binding.value.options);
+        // }
     },
     updated(el: HTMLElement, binding: DirectiveBinding) {
         // update content and options
-        (el as any)._tippy.setContent(el.textContent);
-        if (binding.value && binding.value.options) {
-            (el as any)._tippy.set(binding.value.options);
+        if ((el as any)._tippy) {
+            (el as any)._tippy.setContent(el.textContent);
+            if (binding.value && binding.value.options) {
+                (el as any)._tippy.set(binding.value.options);
+            }
         }
     },
     unmounted(el: HTMLElement) {

--- a/packages/ramp-core/src/fixtures/mapnav/button.vue
+++ b/packages/ramp-core/src/fixtures/mapnav/button.vue
@@ -1,8 +1,5 @@
 <template>
-    <div
-        class="relative w-32 h-32 text-gray-600 hover:text-black"
-        tabindex="-1"
-    >
+    <div class="relative w-32 h-32 text-gray-600 hover:text-black" tabindex="-1">
         <!-- <button
             class="w-full h-full default-focus-style focus:outline-none"
             @click="onClickFunction()"

--- a/packages/ramp-core/src/geo/map/maptip.ts
+++ b/packages/ramp-core/src/geo/map/maptip.ts
@@ -20,9 +20,7 @@ export class MaptipAPI extends APIScope {
      */
     async updateAtCoord(screenPoint: ScreenPoint): Promise<void> {
         // Get the graphic object
-        const graphicHit:
-            | GraphicHitResult
-            | undefined = await this.$iApi.geo.map.getGraphicAtCoord(
+        const graphicHit: GraphicHitResult | undefined = await this.$iApi.geo.map.getGraphicAtCoord(
             screenPoint
         );
 
@@ -32,9 +30,7 @@ export class MaptipAPI extends APIScope {
         }
 
         // Check if the same maptip already exists
-        const currentMaptip:
-            | MaptipProperties
-            | undefined = this.getProperties();
+        const currentMaptip: MaptipProperties | undefined = this.getProperties();
         if (
             currentMaptip &&
             currentMaptip.graphicHit.layerId === graphicHit.layerId &&
@@ -47,14 +43,12 @@ export class MaptipAPI extends APIScope {
         }
 
         // Get the layer
-        const layerInstance:
-            | LayerInstance
-            | undefined = this.$iApi.geo.layer.getLayer(graphicHit.layerId);
+        const layerInstance: LayerInstance | undefined = this.$iApi.geo.layer.getLayer(
+            graphicHit.layerId
+        );
         if (!layerInstance) {
             // Something seriously wrong here because esri gave us a non-existent layerID
-            console.error(
-                `graphic hit test returned non-existent layer id: ${graphicHit.layerId}`
-            );
+            console.error(`graphic hit test returned non-existent layer id: ${graphicHit.layerId}`);
             return;
         }
 
@@ -87,10 +81,7 @@ export class MaptipAPI extends APIScope {
      * @param {MaptipProperties} maptipProperties The maptip object
      */
     setProperties(maptipProperties: MaptipProperties): void {
-        this.$iApi.$vApp.$store.set(
-            MaptipStore.setMaptipProperties,
-            maptipProperties
-        );
+        this.$iApi.$vApp.$store.set(MaptipStore.setMaptipProperties, maptipProperties);
     }
 
     /**
@@ -135,9 +126,6 @@ export class MaptipAPI extends APIScope {
      * @param {string} content the new default maptip html content
      */
     setDefaultContent(content: string): void {
-        this.$iApi.$vApp.$store.set(
-            MaptipStore.setMaptipDefaultContent,
-            content
-        );
+        this.$iApi.$vApp.$store.set(MaptipStore.setMaptipDefaultContent, content);
     }
 }

--- a/packages/ramp-core/src/geo/map/ramp-map.ts
+++ b/packages/ramp-core/src/geo/map/ramp-map.ts
@@ -1,13 +1,7 @@
 // wraps and represents a 2D esri map
 // TODO add proper comments
 
-import {
-    CommonMapAPI,
-    GlobalEvents,
-    InstanceAPI,
-    LayerInstance,
-    MaptipAPI
-} from '@/api/internal';
+import { CommonMapAPI, GlobalEvents, InstanceAPI, LayerInstance, MaptipAPI } from '@/api/internal';
 import {
     BaseGeometry,
     CoreFilter,
@@ -88,9 +82,7 @@ export class MapAPI extends CommonMapAPI {
 
         // TODO if .esriMap or .esriView exists, do we want to do any cleanup on it? E.g. remove event handlers?
 
-        this._rampSR = SpatialReference.fromConfig(
-            config.extent.spatialReference
-        );
+        this._rampSR = SpatialReference.fromConfig(config.extent.spatialReference);
 
         const esriViewConfig: __esri.MapViewProperties = {
             map: this.esriMap,
@@ -99,9 +91,7 @@ export class MapAPI extends CommonMapAPI {
                 lods: <Array<EsriLOD>>config.lods,
                 rotationEnabled: false // TODO make rotation a config option?
             },
-            spatialReference: this.$iApi.geo.utils.geom._convSrToEsri(
-                this._rampSR
-            ), // internal, so we will sneak an internal call
+            spatialReference: this.$iApi.geo.utils.geom._convSrToEsri(this._rampSR), // internal, so we will sneak an internal call
             extent: config.extent,
             navigation: {
                 browserTouchPanEnabled: false
@@ -117,10 +107,7 @@ export class MapAPI extends CommonMapAPI {
             //       between them. They can subscribe to the filter event and get all the info they need.
 
             const newExtent = <Extent>(
-                this.$iApi.geo.utils.geom.geomEsriToRamp(
-                    newval,
-                    'map_extent_event'
-                )
+                this.$iApi.geo.utils.geom.geomEsriToRamp(newval, 'map_extent_event')
             );
             this.$iApi.event.emit(GlobalEvents.MAP_EXTENTCHANGE, newExtent);
             this.$iApi.event.emit(GlobalEvents.FILTER_CHANGE, {
@@ -146,20 +133,14 @@ export class MapAPI extends CommonMapAPI {
         this.esriView.on('click', esriClick => {
             this.$iApi.event.emit(
                 GlobalEvents.MAP_CLICK,
-                this.$iApi.geo.utils.geom.esriMapClickToRamp(
-                    esriClick,
-                    'map_click_point'
-                )
+                this.$iApi.geo.utils.geom.esriMapClickToRamp(esriClick, 'map_click_point')
             );
         });
 
         this.esriView.on('double-click', esriClick => {
             this.$iApi.event.emit(
                 GlobalEvents.MAP_DOUBLECLICK,
-                this.$iApi.geo.utils.geom.esriMapClickToRamp(
-                    esriClick,
-                    'map_doubleclick_point'
-                )
+                this.$iApi.geo.utils.geom.esriMapClickToRamp(esriClick, 'map_doubleclick_point')
             );
         });
 
@@ -173,10 +154,7 @@ export class MapAPI extends CommonMapAPI {
 
         this.esriView.on('pointer-down', esriMouseDown => {
             // .native is a DOM pointer event
-            this.$iApi.event.emit(
-                GlobalEvents.MAP_MOUSEDOWN,
-                esriMouseDown.native
-            );
+            this.$iApi.event.emit(GlobalEvents.MAP_MOUSEDOWN, esriMouseDown.native);
         });
 
         this.esriView.on('key-down', esriKeyDown => {
@@ -205,10 +183,7 @@ export class MapAPI extends CommonMapAPI {
         this._viewPromise.resolveMe();
 
         // emit basemap changed event
-        this.$iApi.event.emit(
-            GlobalEvents.MAP_BASEMAPCHANGE,
-            config.initialBasemapId
-        );
+        this.$iApi.event.emit(GlobalEvents.MAP_BASEMAPCHANGE, config.initialBasemapId);
     }
 
     /**
@@ -220,17 +195,12 @@ export class MapAPI extends CommonMapAPI {
      */
     private geomToMapSR(geom: BaseGeometry): Promise<BaseGeometry> {
         if (!this._rampSR) {
-            throw new Error(
-                'call to map.geomToMapSR before the map spatial ref was created'
-            );
+            throw new Error('call to map.geomToMapSR before the map spatial ref was created');
         }
         if (this._rampSR.isEqual(geom.sr)) {
             return Promise.resolve(geom);
         } else {
-            return this.$iApi.geo.utils.proj.projectGeometry(
-                this._rampSR,
-                geom
-            );
+            return this.$iApi.geo.utils.proj.projectGeometry(this._rampSR, geom);
         }
     }
 
@@ -268,15 +238,11 @@ export class MapAPI extends CommonMapAPI {
             return;
         }
         if (layer.esriLayer) {
-            const layers = this.$vApp.$store.get<LayerInstance[]>(
-                LayerStore.layers
-            )!;
+            const layers = this.$vApp.$store.get<LayerInstance[]>(LayerStore.layers)!;
             // number of layers in store but not on map, probably errored (up to target index)
             const notLoaded: number = layers
                 .slice(0, index + 1)
-                .filter(
-                    layer => !this.esriMap!.layers.find(l => l.id === layer.id)
-                ).length;
+                .filter(layer => !this.esriMap!.layers.find(l => l.id === layer.id)).length;
             // calculate corresponding map layer index
             const esriLayerIndex: number = this.esriMap.layers.indexOf(
                 this.esriMap.layers
@@ -338,10 +304,7 @@ export class MapAPI extends CommonMapAPI {
         this.$iApi.$vApp.$store.set(LayerStore.removeLayer, layerInstance);
 
         // Clean up the layer config store
-        this.$iApi.$vApp.$store.set(
-            LayerStore.removeLayerConfig,
-            layerInstance.id
-        );
+        this.$iApi.$vApp.$store.set(LayerStore.removeLayerConfig, layerInstance.id);
 
         // Remove the layer from the map
         this.esriMap.remove(layerInstance.esriLayer);
@@ -372,11 +335,7 @@ export class MapAPI extends CommonMapAPI {
      * @param {boolean} [animate] An optional animation setting. On by default
      * @returns {Promise<void>} A promise that resolves when the map has finished zooming
      */
-    async zoomMapTo(
-        geom: BaseGeometry,
-        scale?: number,
-        animate: boolean = true
-    ): Promise<void> {
+    async zoomMapTo(geom: BaseGeometry, scale?: number, animate: boolean = true): Promise<void> {
         // TODO technically this can accept any geometry. should we open up the suggested signatures to allow various things?
         if (this.esriView) {
             const g = await this.geomToMapSR(geom);
@@ -495,9 +454,7 @@ export class MapAPI extends CommonMapAPI {
      * @param {__esri.MapViewTakeScreenshotOptions} options ESRI takeScreenshot() options
      * @returns {Promise<Screenshot>} a promise that resolves with a Screenshot
      */
-    async takeScreenshot(
-        options: __esri.MapViewTakeScreenshotOptions
-    ): Promise<Screenshot> {
+    async takeScreenshot(options: __esri.MapViewTakeScreenshotOptions): Promise<Screenshot> {
         if (this.esriView) {
             if (!options.quality) {
                 options.quality = 1;
@@ -560,9 +517,7 @@ export class MapAPI extends CommonMapAPI {
      */
     getExtent(): Extent {
         if (this.esriView) {
-            return this.$iApi.geo.utils.geom._convEsriExtentToRamp(
-                this.esriView.extent
-            );
+            return this.$iApi.geo.utils.geom._convEsriExtentToRamp(this.esriView.extent);
         } else {
             this.noMapErr();
             return Extent.fromParams('i_am_error', 0, 1, 0, 1); // default fake value. avoids us having undefined checks everywhere.
@@ -695,9 +650,7 @@ export class MapAPI extends CommonMapAPI {
      */
 
     identify(payload: MapClick | Point) {
-        let layers: LayerInstance[] | undefined = this.$vApp.$store.get(
-            LayerStore.layers
-        );
+        let layers: LayerInstance[] | undefined = this.$vApp.$store.get(LayerStore.layers);
 
         // Don't perform an identify request if the layers array hasn't been established yet.
         if (layers === undefined) return;
@@ -748,21 +701,21 @@ export class MapAPI extends CommonMapAPI {
      * @param {ScreenPoint} screenPoint The screen coordinates
      * @returns {Promise<GraphicHitResult | undefined>} a promise that resolves when a graphic is hit (undefined if no graphic was hit)
      */
-    async getGraphicAtCoord(
-        screenPoint: ScreenPoint
-    ): Promise<GraphicHitResult | undefined> {
+    async getGraphicAtCoord(screenPoint: ScreenPoint): Promise<GraphicHitResult | undefined> {
         if (!this.esriView) {
             this.noMapErr();
             return;
         }
 
         // Sync with layer store to get the top-most layer with respect to order of layers in the store
-        const layers: LayerInstance[] | undefined = this.$vApp.$store.get<
-            LayerInstance[]
-        >(LayerStore.layers);
+        const layers: LayerInstance[] | undefined = this.$vApp.$store.get<LayerInstance[]>(
+            LayerStore.layers
+        );
 
         // Don't perform a hittest request if the layers array hasn't been established yet.
-        if (layers === undefined) return;
+        if (layers === undefined) {
+            return;
+        }
 
         const response: __esri.HitTestResult = await this.esriView.hitTest({
             x: screenPoint.screenX,
@@ -787,9 +740,7 @@ export class MapAPI extends CommonMapAPI {
         });
         if (esriGraphic && hitLayer) {
             if (hitLayer.getLayerTree().children.length > 1) {
-                console.warn(
-                    'Found layer with more than one child during hitTest'
-                );
+                console.warn('Found layer with more than one child during hitTest');
             }
             return {
                 oid: esriGraphic.getObjectId(),
@@ -813,28 +764,15 @@ export class MapAPI extends CommonMapAPI {
      */
     mapKeyDown(payload: KeyboardEvent) {
         const zoomKeys = ['=', '-'];
-        const panKeys = [
-            'Shift',
-            'Control',
-            'ArrowDown',
-            'ArrowLeft',
-            'ArrowRight',
-            'ArrowUp'
-        ];
+        const panKeys = ['Shift', 'Control', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'ArrowUp'];
 
-        if (
-            panKeys.includes(payload.key) &&
-            !this._activeKeys.includes(payload.key)
-        ) {
+        if (panKeys.includes(payload.key) && !this._activeKeys.includes(payload.key)) {
             this._activeKeys.push(payload.key);
             // don't pan in middle of zoom animation
             if (!this._activeKeys.some(k => zoomKeys.includes(k))) {
                 this.keyPan();
             }
-        } else if (
-            zoomKeys.includes(payload.key) &&
-            !this._activeKeys.includes(payload.key)
-        ) {
+        } else if (zoomKeys.includes(payload.key) && !this._activeKeys.includes(payload.key)) {
             this._activeKeys.push(payload.key);
             this.keyZoom(payload);
         } else if (payload.key === 'Enter') {
@@ -852,10 +790,7 @@ export class MapAPI extends CommonMapAPI {
         const zoomKeys = ['=', '-'];
 
         // ignore zoom keys, manually deactivate them when zoom finishes so keyup won't interrupt zoom animation
-        if (
-            this._activeKeys.includes(payload.key) &&
-            !zoomKeys.includes(payload.key)
-        ) {
+        if (this._activeKeys.includes(payload.key) && !zoomKeys.includes(payload.key)) {
             this._activeKeys.splice(this._activeKeys.indexOf(payload.key), 1);
             // don't pan in middle of zoom animation
             if (!this._activeKeys.some(k => zoomKeys.includes(k))) {
@@ -881,10 +816,7 @@ export class MapAPI extends CommonMapAPI {
      * @returns {boolean} - true if any pan/zoom keys are active
      */
     get keysActive(): boolean {
-        return (
-            this._activeKeys.filter(k => !['Control', 'Shift'].includes(k))
-                .length !== 0
-        );
+        return this._activeKeys.filter(k => !['Control', 'Shift'].includes(k)).length !== 0;
     }
 
     /**

--- a/packages/ramp-core/src/styles/main.css
+++ b/packages/ramp-core/src/styles/main.css
@@ -1,6 +1,6 @@
 .ramp-app {
-    font-family: 'Montserrat', -apple-system, BlinkMacSystemFont, Segoe UI,
-        Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji;
+    font-family: 'Montserrat', -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial,
+        sans-serif, Apple Color Emoji, Segoe UI Emoji;
     font-size: 16px;
     line-height: 1.5;
     word-wrap: break-word;
@@ -16,8 +16,8 @@
 
 /* Change ag-grid theme default font (Roboto) to match the rest of the page. */
 .ramp-app .ag-theme-material * {
-    font-family: 'Montserrat', -apple-system, BlinkMacSystemFont, Segoe UI,
-        Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji;
+    font-family: 'Montserrat', -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial,
+        sans-serif, Apple Color Emoji, Segoe UI Emoji;
 }
 
 /* styling for rectangle when Shift+Left-click+Drag zooming */
@@ -43,15 +43,6 @@
     stroke: #1e90ff;
     stroke-dasharray: 1, 1;
     stroke-width: 2px;
-}
-
-.tippy-tooltip.ramp-theme {
-    font-family: 'Montserrat', -apple-system, BlinkMacSystemFont, Segoe UI,
-        Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji;
-}
-
-.tippy-tooltip.ramp-theme svg {
-    display: inline;
 }
 
 @font-face {
@@ -82,4 +73,25 @@
     border: 2px solid red;
     font-size: x-large;
     background-color: white;
+}
+
+.tippy-box[data-theme~='ramp4'] {
+    font-family: 'Montserrat', -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial,
+        sans-serif, Apple Color Emoji, Segoe UI Emoji;
+    color: white;
+    background: #222;
+    opacity: 0.9;
+    font-size: 14px;
+    padding: 3px 8px;
+    border-radius: 5px;
+    text-align: center;
+}
+
+.tippy-box[data-theme~='ramp4'] svg {
+    display: inline;
+}
+
+.tippy-box[data-inertia][data-state='visible'] {
+    transition-timing-function: cubic-bezier(0.165, 0.84, 0.44, 1);
+    transition-duration: 300ms;
 }


### PR DESCRIPTION
**Changes in this PR**
- re-added tippy styles
- map feature hovertips now work correctly

**Concerns**
- The styles for tippy had to be added manually. The default tippy themes need to be imported, however the import statement provided in the documents doesn't work and I can't find the stylesheet anywhere.
- Animations are also broken. Not sure what's up with this.
- Some buttons don't have their tooltips (for example, the `more options` button in the legend, and the mapnav fixture buttons)

**Testing this PR**
You can find a demo for this PR [here](http://ramp4-app.azureedge.net/demo/users/RyanCoulsonCA/vue3-tippy-fix/host/index.html).

To test, just hover over a feature on the map. You should see the tooltip appear with the feature information. Hovering over other buttons with tooltips should now be styled instead of just showing plaintext.