### PR TITLE
Migrate legend fixture

### DIFF
--- a/packages/ramp-core/src/fixtures/legend/components/checkbox.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/checkbox.vue
@@ -13,95 +13,90 @@
             class="mx-5 h-15 w-15 border-gray-500 hover:border-black"
             tabindex="-1"
             :disabled="disabled"
-            :content="
-                $t(
-                    checked
-                        ? 'legend.visibility.hide'
-                        : 'legend.visibility.show'
-                )
-            "
+            :content="$t(checked ? 'legend.visibility.hide' : 'legend.visibility.show')"
             v-tippy="{ placement: 'top-end', hideOnClick: false }"
         />
     </div>
 </template>
 
 <script lang="ts">
-import { CoreFilter, LayerType } from '@/geo/api';
-import { Vue, Prop } from 'vue-property-decorator';
-import {
-    LegendEntry,
-    LegendGroup,
-    LegendItem,
-    LegendSet
-} from '../store/legend-defs';
+import { defineComponent, PropType } from 'vue';
+import { CoreFilter, LayerType, LegendSymbology } from '@/geo/api';
+import { LegendEntry, LegendItem } from '../store/legend-defs';
 
-export default class CheckboxV extends Vue {
-    @Prop() value!: any;
-    @Prop() legendItem!: LegendEntry;
-    @Prop() checked!: boolean;
-    @Prop() isRadio!: boolean;
-    @Prop() disabled!: boolean;
+export default defineComponent({
+    name: 'CheckboxV',
+    props: {
+        value: { type: Object as PropType<LegendEntry | LegendSymbology>, required: true },
+        legendItem: { type: Object as PropType<LegendEntry>, required: true },
+        checked: { type: Boolean },
+        isRadio: { type: Boolean },
+        disabled: { type: Boolean }
+    },
+    methods: {
+        /**
+         * Returns true if non of the child symbols are visible
+         * @returns {boolean} Boolean value that is true when no child symbols are visible
+         */
+        _noSymbolsVisible(): boolean {
+            return !this.legendItem.layer
+                ?.getLegend()
+                .some((item: LegendSymbology) => item.visibility);
+        },
 
-    /**
-     * Returns true if non of the child symbols are visible
-     * @returns {boolean} Boolean value that is true when no child symbols are visible
-     */
-    _noSymbolsVisible(): boolean {
-        return !this.legendItem.layer
-            ?.getLegend()
-            .some(item => item.visibility);
-    }
+        /**
+         * Toggle this visibility of the value object linked with this checkbox
+         */
+        toggleVisibility(): void {
+            if (this.value instanceof LegendItem) {
+                // Toggle parent symbology checkbox
 
-    toggleVisibility(): void {
-        if (this.value instanceof LegendItem) {
-            // Toggle parent symbology checkbox
-
-            this.legendItem.toggleVisibility();
-        } else {
-            // Toggle child symbology checkbox
-
-            if (this._noSymbolsVisible()) {
-                // If no symbols are visible, then set the parent layer to visible
-                // since we toggled on one of the child symbols and set all other
-                // symbols to invisible (except for the one that is toggled on)
-
-                this.legendItem._layer?.getLegend().forEach(item => {
-                    item.visibility = false;
-                    item.lastVisbility = false;
-                });
-
-                this.value.visibility = true;
-                this.value.lastVisbility = true;
-
-                if (!this.legendItem.visibility) {
-                    this.legendItem.toggleVisibility(true);
-                }
+                this.legendItem.toggleVisibility();
             } else {
-                // Toggle the child symbology
-                this.value.lastVisbility = !this.value.lastVisbility;
-                this.value.visibility = this.value.lastVisbility;
+                // Toggle child symbology checkbox
+                if (this._noSymbolsVisible()) {
+                    // If no symbols are visible, then set the parent layer to visible
+                    // since we toggled on one of the child symbols and set all other
+                    // symbols to invisible (except for the one that is toggled on)
+
+                    this.legendItem._layer?.getLegend().forEach((item: LegendSymbology) => {
+                        this.legendItem.setChildSymbologyVisibility(item.uid, false);
+                    });
+
+                    this.legendItem.setChildSymbologyVisibility(this.value.uid, true);
+
+                    if (!this.legendItem.visibility) {
+                        this.legendItem.toggleVisibility(true);
+                    }
+                } else {
+                    // Toggle the child symbology
+                    this.legendItem.setChildSymbologyVisibility(
+                        this.value.uid,
+                        !this.value.lastVisbility
+                    );
+                }
+
+                // If all child symbols are toggled off, then toggle off the parent layer too
+                if (this._noSymbolsVisible()) {
+                    this.legendItem.toggleVisibility(false);
+                }
             }
 
-            // If all child symbols are toggled off, then toggle off the parent layer too
-            if (this._noSymbolsVisible()) {
-                this.legendItem.toggleVisibility(false);
+            // Update the layer definition to filter child symbols
+            // WMS layers do not have child symbology
+            if (this.legendItem.layer?.layerType !== LayerType.WMS) {
+                this.legendItem.layer?.setSqlFilter(
+                    CoreFilter.SYMBOL,
+                    this.legendItem.layer
+                        ?.getLegend()
+                        .filter((item: LegendSymbology) => item.lastVisbility === true)
+                        .map((item: LegendSymbology) => item.definitionClause)
+                        .join(' OR ')
+                );
             }
-        }
-
-        // Update the layer definition to filter child symbols
-        // WMS layers do not have child symbology
-        if (this.legendItem.layer?.layerType !== LayerType.WMS) {
-            this.legendItem.layer?.setSqlFilter(
-                CoreFilter.SYMBOL,
-                this.legendItem.layer
-                    ?.getLegend()
-                    .filter(item => item.lastVisbility === true)
-                    .map(item => item.definitionClause)
-                    .join(' OR ')
-            );
         }
     }
-}
+});
 </script>
 
 <style lang="scss"></style>

--- a/packages/ramp-core/src/fixtures/legend/components/component.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/component.vue
@@ -1,34 +1,39 @@
 <template>
     <component
         class="select-none"
-        :is="templates[legendItem.type]"
+        :is="getCurrentTemplate()"
         :legendItem="legendItem"
         :props="props"
+        :key="legendItem.uid"
     ></component>
 </template>
 
 <script lang="ts">
-import { Vue, Prop } from 'vue-property-decorator';
-
-import { LegendItem, LegendTypes } from '../store/legend-defs';
-
 import LayerEntryV from './entry.vue';
 import LegendGroupV from './group.vue';
 import LegendVisibilitySetV from './visibility-set.vue';
 import LegendPlaceholderV from './placeholder.vue';
+import { defineComponent, PropType } from 'vue';
+import { LegendItem, LegendTypes } from '../store/legend-defs';
 
-export default class LegendComponentV extends Vue {
-    @Prop() legendItem!: LegendItem;
-    @Prop() props!: any;
-
-    // Binds each type to its respective Vue component.
-    templates = {
-        [LegendTypes.Set]: LegendVisibilitySetV,
-        [LegendTypes.Group]: LegendGroupV,
-        [LegendTypes.Entry]: LayerEntryV,
-        [LegendTypes.Placeholder]: LegendPlaceholderV
-    };
-}
+export default defineComponent({
+    name: 'LegendComponentV',
+    props: {
+        legendItem: { type: Object as PropType<LegendItem>, required: true },
+        props: { type: Object }
+    },
+    methods: {
+        getCurrentTemplate(): string {
+            const templates: any = {
+                [LegendTypes.Set]: LegendVisibilitySetV,
+                [LegendTypes.Group]: LegendGroupV,
+                [LegendTypes.Entry]: LayerEntryV,
+                [LegendTypes.Placeholder]: LegendPlaceholderV
+            };
+            return templates[this.legendItem.type];
+        }
+    }
+});
 </script>
 
 <style lang="scss" scoped></style>

--- a/packages/ramp-core/src/fixtures/legend/components/group.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/group.vue
@@ -5,13 +5,7 @@
                 class="legend-group-header flex items-center px-5 py-10 cursor-pointer default-focus-style hover:bg-gray-200"
                 @click="legendItem.toggleExpanded()"
                 v-focus-item="'show-truncate'"
-                :content="
-                    $t(
-                        legendItem.expanded
-                            ? 'legend.group.collapse'
-                            : 'legend.group.expand'
-                    )
-                "
+                :content="$t(legendItem.expanded ? 'legend.group.collapse' : 'legend.group.expand')"
                 v-tippy="{ placement: 'top-start', aria: 'describedby' }"
                 truncate-trigger
             >
@@ -27,9 +21,7 @@
                         width="24"
                     >
                         <path d="M0 0h24v24H0V0z" fill="none" />
-                        <path
-                            d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
-                        />
+                        <path d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z" />
                     </svg>
                 </div>
 
@@ -42,10 +34,7 @@
                 <checkbox
                     :checked="legendItem.visibility"
                     :value="legendItem"
-                    :isRadio="
-                        legendItem.parent &&
-                            legendItem.parent.type === LegendTypes.Set
-                    "
+                    :isRadio="legendItem.parent && legendItem.parent.type === LegendTypes.Set"
                     :legendItem="legendItem"
                 />
             </div>
@@ -63,24 +52,23 @@
 </template>
 
 <script lang="ts">
-import { Vue, Options, Prop, Watch } from 'vue-property-decorator';
-import { defineAsyncComponent } from 'vue';
-
+import { defineComponent, defineAsyncComponent, PropType } from 'vue';
 import { LegendGroup, LegendTypes } from '../store/legend-defs';
 import LegendCheckboxV from './checkbox.vue';
 
-@Options({
+export default defineComponent({
+    name: 'LegendGroupV',
+    props: {
+        legendItem: { type: Object as PropType<LegendGroup>, required: true }
+    },
     components: {
         LegendComponent: defineAsyncComponent(() => import('./component.vue')),
         checkbox: LegendCheckboxV
+    },
+    data() {
+        return { LegendTypes: LegendTypes };
     }
-})
-export default class LegendGroupV extends Vue {
-    @Prop() legendItem!: LegendGroup;
-
-    // make vue stop hating enums
-    LegendTypes = LegendTypes;
-}
+});
 </script>
 
 <style lang="scss" scoped>

--- a/packages/ramp-core/src/fixtures/legend/components/legend-options.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/legend-options.vue
@@ -5,7 +5,6 @@
             position="left-start"
             :tooltip="$t('legend.entry.options')"
             tooltip-placement="left"
-            :key="legendItem.uid"
         >
             <template #header>
                 <div class="flex p-8">

--- a/packages/ramp-core/src/fixtures/legend/components/visibility-set.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/visibility-set.vue
@@ -5,13 +5,7 @@
                 class="legend-group-header flex items-center px-5 py-10 cursor-pointer default-focus-style hover:bg-gray-200"
                 @click="legendItem.toggleExpanded()"
                 v-focus-item="'show-truncate'"
-                :content="
-                    $t(
-                        legendItem.expanded
-                            ? 'legend.group.collapse'
-                            : 'legend.group.expand'
-                    )
-                "
+                :content="$t(legendItem.expanded ? 'legend.group.collapse' : 'legend.group.expand')"
                 v-tippy="{ placement: 'top-start', aria: 'describedby' }"
                 truncate-trigger
             >
@@ -27,27 +21,19 @@
                         width="24"
                     >
                         <path d="M0 0h24v24H0V0z" fill="none" />
-                        <path
-                            d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
-                        />
+                        <path d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z" />
                     </svg>
                 </div>
 
                 <!-- name -->
-                <div
-                    class="flex-1 pointer-events-none"
-                    v-truncate="{ externalTrigger: true }"
-                >
+                <div class="flex-1 pointer-events-none" v-truncate="{ externalTrigger: true }">
                     <span>{{ legendItem.name }}</span>
                 </div>
 
                 <!-- visibility -->
                 <checkbox
                     :value="legendItem"
-                    :isRadio="
-                        legendItem.parent &&
-                            legendItem.parent.type === LegendTypes.Set
-                    "
+                    :isRadio="legendItem.parent && legendItem.parent.type === LegendTypes.Set"
                     :legendItem="legendItem"
                 />
             </div>
@@ -65,24 +51,23 @@
 </template>
 
 <script lang="ts">
-import { defineAsyncComponent } from 'vue';
-import { Vue, Options, Prop } from 'vue-property-decorator';
-
+import { defineComponent, defineAsyncComponent, PropType } from 'vue';
 import { LegendSet, LegendTypes } from '../store/legend-defs';
 import LegendCheckboxV from './checkbox.vue';
 
-@Options({
+export default defineComponent({
+    name: 'LegendVisibilitySetV',
+    props: {
+        legendItem: { type: Object as PropType<LegendSet>, required: true }
+    },
     components: {
         LegendComponent: defineAsyncComponent(() => import('./component.vue')),
         checkbox: LegendCheckboxV
+    },
+    data() {
+        return { LegendTypes: LegendTypes };
     }
-})
-export default class LegendVisibilitySetV extends Vue {
-    @Prop() legendItem!: LegendSet;
-
-    // make vue stop hating enums
-    LegendTypes = LegendTypes;
-}
+});
 </script>
 
 <style lang="scss" scoped>

--- a/packages/ramp-core/src/fixtures/legend/screen.vue
+++ b/packages/ramp-core/src/fixtures/legend/screen.vue
@@ -5,7 +5,7 @@
         </template>
 
         <template #controls>
-            <pin @click="panel.pin()" :active="isPinned"></pin>
+            <pin @click="panel.pin()" :active="this.panel.isPinned"></pin>
             <close @click="panel.close()"></close>
         </template>
 
@@ -23,33 +23,27 @@
 </template>
 
 <script lang="ts">
-import { Vue, Options, Prop } from 'vue-property-decorator';
-import { Get } from 'vuex-pathify';
 import { get } from '@/store/pathify-helper';
 import { PanelInstance } from '@/api';
-import { ComputedRef } from 'vue';
+import { defineComponent, PropType } from 'vue';
 
 import { LegendStore } from './store';
-import { LegendEntry, LegendGroup } from './store/legend-defs';
 import LegendHeaderV from './header.vue';
 import LegendComponentV from './components/component.vue';
 
-@Options({
+export default defineComponent({
+    name: 'LegendScreenV',
+    props: {
+        panel: { type: Object as PropType<PanelInstance>, required: true }
+    },
     components: {
         'legend-header': LegendHeaderV,
         'legend-component': LegendComponentV
+    },
+    data() {
+        return { children: get(LegendStore.children) };
     }
-})
-export default class LegendScreenV extends Vue {
-    @Prop() panel!: PanelInstance;
-    // fetch store properties/data
-    children: ComputedRef<Array<LegendEntry | LegendGroup>> = get(LegendStore.children);
-    // @Get(LegendStore.children) children!: Array<LegendEntry | LegendGroup>;
-
-    get isPinned(): boolean {
-        return this.panel.isPinned;
-    }
-}
+});
 </script>
 
 <style lang="scss" scoped></style>

--- a/packages/ramp-core/src/fixtures/legend/store/legend-store.ts
+++ b/packages/ramp-core/src/fixtures/legend/store/legend-store.ts
@@ -3,12 +3,7 @@ import { make } from 'vuex-pathify';
 import Vue from 'vue';
 
 import { LegendState } from './legend-state';
-import {
-    LegendItem,
-    LegendEntry,
-    LegendGroup,
-    LegendTypes
-} from './legend-defs';
+import { LegendItem, LegendEntry, LegendGroup, LegendTypes } from './legend-defs';
 import { RootState } from '@/store';
 import { TreeNode } from '@/geo/api';
 import { LayerInstance } from '@/api';
@@ -17,9 +12,7 @@ import { LayerInstance } from '@/api';
 type LegendContext = ActionContext<LegendState, RootState>;
 
 const getters = {
-    getChildById: (state: LegendState) => (
-        id: string
-    ): LegendItem | undefined => {
+    getChildById: (state: LegendState) => (id: string): LegendItem | undefined => {
         const searchTree = function(root: any, id: string) {
             if (root.id === id) {
                 return root;
@@ -36,9 +29,7 @@ const getters = {
     },
     getAllExpanded: (state: LegendState, expanded: boolean): boolean => {
         return state.children.every(
-            (entry: LegendItem) =>
-                !(entry instanceof LegendGroup) ||
-                checkExpanded(entry, expanded)
+            (entry: LegendItem) => !(entry instanceof LegendGroup) || checkExpanded(entry, expanded)
         );
     },
     getAllVisibility: (state: LegendState, visible: boolean): boolean => {
@@ -77,8 +68,7 @@ const mutations = {
 
             // remove groups with no children
             children = children.filter(
-                item =>
-                    item instanceof LegendEntry || item.children.length !== 0
+                item => item instanceof LegendEntry || item.children.length !== 0
             );
 
             return children;
@@ -93,7 +83,7 @@ const mutations = {
                 .filter(
                     entry =>
                         entry instanceof LegendEntry &&
-                        (entry.layer!.uid === uid || entry.layerUID === uid)
+                        (entry.layer?.uid === uid || entry.layerUID === uid)
                 )
                 .forEach(entry => {
                     entry._type = LegendTypes.Placeholder;
@@ -201,10 +191,7 @@ const actions = {
  * @param {LegendElement}   child Current legend item that is being checked
  * @param {boolean}         visible Specifies whether visibility or expand/collapse functionality is to be changed
  */
-function checkVisibility(
-    child: LegendEntry | LegendGroup,
-    visible: boolean
-): boolean {
+function checkVisibility(child: LegendEntry | LegendGroup, visible: boolean): boolean {
     // traverse tree to check if all legend items have visibility toggled on/off
     if (child.children && child.children.length > 0) {
         child.children.forEach(ch => {
@@ -214,10 +201,7 @@ function checkVisibility(
         });
     }
     // visibility set edge case: entry must be toggled on or must be part of a visbiility set and there is another entry in the set toggled on
-    if (
-        !child.visibility &&
-        !(child.parent instanceof LegendGroup && child.parent.visibility)
-    ) {
+    if (!child.visibility && !(child.parent instanceof LegendGroup && child.parent.visibility)) {
         return false;
     } else if (child.visibility !== visible) {
         return false;
@@ -260,12 +244,7 @@ function toggle(child: LegendEntry | LegendGroup, options: any) {
     // for current legend child toggle properties if possible, check for appropriate legend element type
     if (visibility !== undefined) {
         // visibility set edge case
-        if (
-            !(
-                child.parent instanceof LegendGroup &&
-                child.parent.visibility === visibility
-            )
-        ) {
+        if (!(child.parent instanceof LegendGroup && child.parent.visibility === visibility)) {
             child.toggleVisibility(visibility);
         }
     }

--- a/packages/ramp-core/src/geo/api/geo-defs.ts
+++ b/packages/ramp-core/src/geo/api/geo-defs.ts
@@ -258,6 +258,7 @@ export interface TabularAttributeSet {
 }
 
 export interface LegendSymbology {
+    uid: string;
     label: string;
     definitionClause?: string;
     svgcode: string;
@@ -456,9 +457,7 @@ export interface RampLayerConfig {
     nameField?: string;
     tooltipField?: string;
     featureInfoMimeType?: string;
-    layerEntries?:
-        | Array<RampLayerMapImageLayerEntryConfig>
-        | Array<RampLayerWmsLayerEntryConfig>;
+    layerEntries?: Array<RampLayerMapImageLayerEntryConfig> | Array<RampLayerWmsLayerEntryConfig>;
     rawData?: any; // used for static data, like geojson string, shapefile guts
     latField?: string; // csv coord field
     longField?: string; // csv coord field

--- a/packages/ramp-core/src/geo/layer/ogcWms/wms-fc.ts
+++ b/packages/ramp-core/src/geo/layer/ogcWms/wms-fc.ts
@@ -63,6 +63,7 @@ export class WmsFC extends CommonFC {
                     this.getWMSLayerTitle(configLayerEntries[idx].id) ||
                     configLayerEntries[idx].id;
                 const symbologyItem: LegendSymbology = {
+                    uid: RAMP.GEO.sharedUtils.generateUUID(),
                     label: name,
                     svgcode: '',
                     drawPromise: this.parentLayer.$iApi.geo.utils.symbology

--- a/packages/ramp-core/src/geo/utils/symbology.ts
+++ b/packages/ramp-core/src/geo/utils/symbology.ts
@@ -54,10 +54,7 @@ export class SymbologyAPI extends APIScope {
      * @param {Object} renderer an enhanced renderer (see function enhanceRenderer)
      * @return {Object} an ESRI Symbol object in server format
      */
-    getGraphicSymbol(
-        attributes: Object,
-        renderer: BaseRenderer
-    ): __esri.Symbol {
+    getGraphicSymbol(attributes: Object, renderer: BaseRenderer): __esri.Symbol {
         return renderer.getGraphicSymbol(attributes);
     }
 
@@ -68,10 +65,7 @@ export class SymbologyAPI extends APIScope {
     ): BaseRenderer {
         switch (esriRenderer.type) {
             case this.SIMPLE:
-                return new SimpleRenderer(
-                    <__esri.SimpleRenderer>esriRenderer,
-                    fields
-                );
+                return new SimpleRenderer(<__esri.SimpleRenderer>esriRenderer, fields);
 
             case this.CLASS_BREAKS:
                 return new ClassBreaksRenderer(
@@ -92,9 +86,7 @@ export class SymbologyAPI extends APIScope {
                 //      and return it. that way it won't crash the app.  once done, change back to console error instead of real error
 
                 // console.error(`Unknown renderer type encountered - ${esriRenderer.type}`);
-                throw new Error(
-                    `Unknown renderer type encountered - ${esriRenderer.type}`
-                );
+                throw new Error(`Unknown renderer type encountered - ${esriRenderer.type}`);
         }
     }
 
@@ -145,10 +137,7 @@ export class SymbologyAPI extends APIScope {
      * @param {Array} list a list of config-supplied symbology items in the form of [ { text: <String>, image: <String> }, ... ] wher `image` can be dataURL or an actual url
      * @return {Array} an array of converted symbology symbols in the form of [ { name: <String>, image: <String>, svgcode: <String> }, ... ]; items will be populated async as conversions are done
      */
-    private listToSymbology(
-        conversionFunction: Function,
-        list: Array<any>
-    ): Array<Object> {
+    private listToSymbology(conversionFunction: Function, list: Array<any>): Array<Object> {
         const results = list.map(({ text, image }) => {
             const result = {
                 name: text,
@@ -183,19 +172,14 @@ export class SymbologyAPI extends APIScope {
      * @param {String} imageUri a image dataUrl or a regular url
      * @param {Object} draw [optional=null] an svg container to draw the image on; if not supplied, a new one is created
      */
-    async renderSymbologyImage(
-        imageUri: string,
-        draw: any = null
-    ): Promise<string> {
+    async renderSymbologyImage(imageUri: string, draw: any = null): Promise<string> {
         if (draw === null) {
             draw = svgjs(window.document.createElement('div'))
                 .size(this.CONTAINER_SIZE, this.CONTAINER_SIZE)
                 .viewbox(0, 0, 0, 0);
         }
 
-        const dataUri = await this.$iApi.geo.utils.shared.convertImagetoDataURL(
-            imageUri
-        );
+        const dataUri = await this.$iApi.geo.utils.shared.convertImagetoDataURL(imageUri);
         if (dataUri === imageUri) {
             // Something went wrong
             return '';
@@ -222,10 +206,7 @@ export class SymbologyAPI extends APIScope {
      * @param {String} imageUri a image dataUrl or a regular url
      * @param {Object} draw [optional=null] an svg container to draw the image on; if not supplied, a new one is created
      */
-    async renderSymbologyIcon(
-        imageUri: string,
-        draw: any = null
-    ): Promise<string> {
+    async renderSymbologyIcon(imageUri: string, draw: any = null): Promise<string> {
         if (draw === null) {
             // create a temporary svg element and add it to the page; if not added, the element's bounding box cannot be calculated correctly
             const container = window.document.createElement('div');
@@ -241,9 +222,7 @@ export class SymbologyAPI extends APIScope {
         }
 
         // need to draw the image to get its size (technically not needed if we have a url, but this is simpler)
-        const convertedUrl = await this.$iApi.geo.utils.shared.convertImagetoDataURL(
-            imageUri
-        );
+        const convertedUrl = await this.$iApi.geo.utils.shared.convertImagetoDataURL(imageUri);
 
         const { image } = await this.svgDrawImage(draw, convertedUrl);
 
@@ -263,10 +242,7 @@ export class SymbologyAPI extends APIScope {
      * @param  {String} colour colour to use in the graphic
      * @return {Object} symbology svg code and its label
      */
-    generatePlaceholderSymbology(
-        name: string,
-        colour: string = '#000'
-    ): Object {
+    generatePlaceholderSymbology(name: string, colour: string = '#000'): Object {
         const draw = svgjs(window.document.createElement('div'))
             .size(this.CONTAINER_SIZE, this.CONTAINER_SIZE)
             .viewbox(0, 0, this.CONTAINER_SIZE, this.CONTAINER_SIZE);
@@ -349,16 +325,12 @@ export class SymbologyAPI extends APIScope {
             // @ts-ignore
             cross({ size }) {
                 // esriSMSCross
-                return draw
-                    .path('M 0,10 L 20,10 M 10,0 L 10,20')
-                    .size(size * pts2Pxl);
+                return draw.path('M 0,10 L 20,10 M 10,0 L 10,20').size(size * pts2Pxl);
             },
             // @ts-ignore
             x({ size }) {
                 // esriSMSX
-                return draw
-                    .path('M 0,0 L 20,20 M 20,0 L 0,20')
-                    .size(size * pts2Pxl);
+                return draw.path('M 0,0 L 20,20 M 20,0 L 0,20').size(size * pts2Pxl);
             },
             // @ts-ignore
             triangle({ size }) {
@@ -368,16 +340,12 @@ export class SymbologyAPI extends APIScope {
             // @ts-ignore
             diamond({ size }) {
                 // esriSMSDiamond
-                return draw
-                    .path('M 20,10 L 10,0 0,10 10,20 Z')
-                    .size(size * pts2Pxl);
+                return draw.path('M 20,10 L 10,0 0,10 10,20 Z').size(size * pts2Pxl);
             },
             // @ts-ignore
             square({ size }) {
                 // esriSMSSquare
-                return draw
-                    .path('M 0,0 20,0 20,20 0,20 Z')
-                    .size(size * pts2Pxl);
+                return draw.path('M 0,0 20,0 20,20 0,20 Z').size(size * pts2Pxl);
             }
         };
 
@@ -427,10 +395,7 @@ export class SymbologyAPI extends APIScope {
                 };
             },
             none: () => 'transparent', // esriSFSNull
-            horizontal: (
-                _symbolColour: Object,
-                symbolStroke: svgjs.StrokeData
-            ) => {
+            horizontal: (_symbolColour: Object, symbolStroke: svgjs.StrokeData) => {
                 // esriSFSHorizontal
                 const cellSize = 5;
 
@@ -441,10 +406,7 @@ export class SymbologyAPI extends APIScope {
                     )
                     .stroke(symbolStroke);
             },
-            vertical: (
-                _symbolColour: Object,
-                symbolStroke: svgjs.StrokeData
-            ) => {
+            vertical: (_symbolColour: Object, symbolStroke: svgjs.StrokeData) => {
                 // esriSFSVertical
                 const cellSize = 5;
 
@@ -455,10 +417,7 @@ export class SymbologyAPI extends APIScope {
                     )
                     .stroke(symbolStroke);
             },
-            'forward-diagonal': (
-                _symbolColour: Object,
-                symbolStroke: svgjs.StrokeData
-            ) => {
+            'forward-diagonal': (_symbolColour: Object, symbolStroke: svgjs.StrokeData) => {
                 // esriSFSForwardDiagonal
                 const cellSize = 5;
 
@@ -473,10 +432,7 @@ export class SymbologyAPI extends APIScope {
                         .stroke(symbolStroke);
                 });
             },
-            'backward-diagonal': (
-                _symbolColour: Object,
-                symbolStroke: svgjs.StrokeData
-            ) => {
+            'backward-diagonal': (_symbolColour: Object, symbolStroke: svgjs.StrokeData) => {
                 // esriSFSBackwardDiagonal
                 const cellSize = 5;
 
@@ -497,18 +453,11 @@ export class SymbologyAPI extends APIScope {
 
                 // patter fill: horizonal and vertical lines in a 5x5 px square
                 return draw.pattern(cellSize, cellSize, add => {
-                    add.line(cellSize / 2, 0, cellSize / 2, cellSize).stroke(
-                        symbolStroke
-                    );
-                    add.line(0, cellSize / 2, cellSize, cellSize / 2).stroke(
-                        symbolStroke
-                    );
+                    add.line(cellSize / 2, 0, cellSize / 2, cellSize).stroke(symbolStroke);
+                    add.line(0, cellSize / 2, cellSize, cellSize / 2).stroke(symbolStroke);
                 });
             },
-            'diagonal-cross': (
-                _symbolColour: Object,
-                symbolStroke: svgjs.StrokeData
-            ) => {
+            'diagonal-cross': (_symbolColour: Object, symbolStroke: svgjs.StrokeData) => {
                 // esriSFSDiagonalCross
                 const cellSize = 7;
 
@@ -528,9 +477,7 @@ export class SymbologyAPI extends APIScope {
                 const symbolColour: any = parseEsriColour(symbol.color);
 
                 symbol.outline = symbol.outline || DEFAULT_OUTLINE;
-                const outlineColour: any = parseEsriColour(
-                    symbol.outline.color
-                );
+                const outlineColour: any = parseEsriColour(symbol.outline.color);
                 const outlineStroke = makeStroke({
                     color: outlineColour.colour,
                     opacity: outlineColour.opacity,
@@ -581,15 +528,10 @@ export class SymbologyAPI extends APIScope {
                     opacity: symbolColour.opacity
                 });
                 // @ts-ignore
-                const symbolFill = esriSFSFills[symbol.style](
-                    symbolColour,
-                    symbolStroke
-                );
+                const symbolFill = esriSFSFills[symbol.style](symbolColour, symbolStroke);
 
                 symbol.outline = symbol.outline || DEFAULT_OUTLINE;
-                const outlineColour: any = parseEsriColour(
-                    symbol.outline.color
-                );
+                const outlineColour: any = parseEsriColour(symbol.outline.color);
                 const outlineStroke = makeStroke({
                     color: outlineColour.colour,
                     opacity: outlineColour.opacity,
@@ -607,9 +549,7 @@ export class SymbologyAPI extends APIScope {
 
             text() {
                 // esriTS
-                console.error(
-                    'no support for feature service legend of text symbols'
-                );
+                console.error('no support for feature service legend of text symbols');
             },
 
             'picture-fill'() {
@@ -623,9 +563,7 @@ export class SymbologyAPI extends APIScope {
                 const imageHeight = symbol.height * symbol.yscale;
 
                 symbol.outline = symbol.outline || DEFAULT_OUTLINE;
-                const outlineColour: any = parseEsriColour(
-                    symbol.outline.color
-                );
+                const outlineColour: any = parseEsriColour(symbol.outline.color);
                 const outlineStroke = makeStroke({
                     color: outlineColour.colour,
                     opacity: outlineColour.opacity,
@@ -638,19 +576,13 @@ export class SymbologyAPI extends APIScope {
                     .convertImagetoDataURL(imageUri)
                     .then((imageUri: string) => {
                         // make a fill from a tiled image
-                        const symbolFill = draw.pattern(
-                            imageWidth,
-                            imageHeight,
-                            add =>
-                                // there was a 4th argument 'true' here before, but maximum 3 are accepted. may need to look into this
-                                add.image(imageUri, imageWidth, imageHeight)
+                        const symbolFill = draw.pattern(imageWidth, imageHeight, add =>
+                            // there was a 4th argument 'true' here before, but maximum 3 are accepted. may need to look into this
+                            add.image(imageUri, imageWidth, imageHeight)
                         );
 
                         draw.rect(_this.CONTENT_SIZE, _this.CONTENT_SIZE)
-                            .center(
-                                _this.CONTAINER_CENTER,
-                                _this.CONTAINER_CENTER
-                            )
+                            .center(_this.CONTAINER_CENTER, _this.CONTAINER_CENTER)
                             .fill(symbolFill)
                             .stroke(outlineStroke);
                     });
@@ -670,15 +602,10 @@ export class SymbologyAPI extends APIScope {
                 // need to draw the image to get its size (technically not needed if we have a url, but this is simpler)
                 const picturePromise = _this.$iApi.geo.utils.shared
                     .convertImagetoDataURL(imageUri)
-                    .then((imageUri: string) =>
-                        _this.svgDrawImage(draw, imageUri)
-                    )
+                    .then((imageUri: string) => _this.svgDrawImage(draw, imageUri))
                     .then(({ image }) => {
                         image
-                            .center(
-                                _this.CONTAINER_CENTER,
-                                _this.CONTAINER_CENTER
-                            )
+                            .center(_this.CONTAINER_CENTER, _this.CONTAINER_CENTER)
                             .rotate(symbol.angle || 0);
 
                         // scale image to fit into the symbology item container
@@ -780,8 +707,7 @@ export class SymbologyAPI extends APIScope {
         // const elementRbox = element.screenBBox();
 
         const elementRbox = element.node.getBoundingClientRect(); // marker.rbox(); //rbox doesn't work properly in Chrome for some reason
-        const scale =
-            CONTAINER_SIZE / Math.max(elementRbox.width, elementRbox.height);
+        const scale = CONTAINER_SIZE / Math.max(elementRbox.width, elementRbox.height);
         if (scale < 1) {
             element.scale(scale);
         }
@@ -796,9 +722,7 @@ export class SymbologyAPI extends APIScope {
     rendererToLegend(renderer: BaseRenderer): Array<LegendSymbology> {
         let finalSymbols: Array<Array<BaseSymbolUnit>>;
         // put all symbol units from the renderer in one nice array
-        const allRendererSUs: Array<BaseSymbolUnit> = renderer.symbolUnits.slice(
-            0
-        ); // make a copy
+        const allRendererSUs: Array<BaseSymbolUnit> = renderer.symbolUnits.slice(0); // make a copy
         if (renderer.defaultUnit) {
             allRendererSUs.push(renderer.defaultUnit);
         }
@@ -835,13 +759,12 @@ export class SymbologyAPI extends APIScope {
         return finalSymbols.map(suSet => {
             const firstSu: BaseSymbolUnit = suSet[0];
             const legendSym: LegendSymbology = {
+                uid: this.$iApi.geo.utils.shared.generateUUID(),
                 label: firstSu.label || '',
                 definitionClause:
                     suSet.length === 1
                         ? firstSu.definitionClause
-                        : `(${suSet
-                              .map(su => su.definitionClause)
-                              .join(' OR ')})`,
+                        : `(${suSet.map(su => su.definitionClause).join(' OR ')})`,
                 svgcode: '', // TODO is '' ok? maybe we need white square svg? or some loading icon?
                 visibility: true,
                 lastVisbility: true,
@@ -904,10 +827,7 @@ export class SymbologyAPI extends APIScope {
      * @returns {Object} a fake unique value renderer based off the legend
      *
      */
-    private mapServerLegendToRenderer(
-        serverLegend: any,
-        layerIndex: number
-    ): BaseRenderer {
+    private mapServerLegendToRenderer(serverLegend: any, layerIndex: number): BaseRenderer {
         const layerLegend = serverLegend.layers.find((l: any) => {
             return l.layerId === layerIndex;
         });
@@ -936,17 +856,11 @@ export class SymbologyAPI extends APIScope {
             };
 
             // ok to pass empty array. this renderer will only be used to generate a legend; no symbol lookups
-            return this.makeRenderer(
-                EsriRendererUtils.fromJSON(renderer),
-                [],
-                true
-            );
+            return this.makeRenderer(EsriRendererUtils.fromJSON(renderer), [], true);
         } else {
             // TODO does this case ever exist? need to figure out a way to encode this in our official renderer objects
             // renderer = { type: this.NONE };
-            throw new Error(
-                'attempted to make renderer from non-existing legend data'
-            ); // so basically if this error hits, we need to write some new code
+            throw new Error('attempted to make renderer from non-existing legend data'); // so basically if this error hits, we need to write some new code
         }
     }
 
@@ -988,11 +902,7 @@ export class SymbologyAPI extends APIScope {
             uniqueValueInfos: [].concat(...layerRenders)
         };
 
-        return this.makeRenderer(
-            EsriRendererUtils.fromJSON(fullRenderer),
-            [],
-            true
-        );
+        return this.makeRenderer(EsriRendererUtils.fromJSON(fullRenderer), [], true);
     }
 
     /**
@@ -1023,10 +933,7 @@ export class SymbologyAPI extends APIScope {
             fakeRenderer = this.mapServerLegendToRendererAll(serverLegendData);
         } else {
             intIndex = parseInt(<string>layerIndex); // sometimes a stringified value comes in. careful now.
-            fakeRenderer = this.mapServerLegendToRenderer(
-                serverLegendData,
-                intIndex
-            );
+            fakeRenderer = this.mapServerLegendToRenderer(serverLegendData, intIndex);
         }
         // convert renderer to viewer specific legend
         return this.rendererToLegend(fakeRenderer);


### PR DESCRIPTION
## Changes in this PR
- Visibility checkboxes now properly work
- Child symbology checkboxes work
- Reloading a layer updates its visibility checkbox as well as its parent entries
- The settings panel visibility switch properly reacts to the layer's visibility
- Refactored all legend related components to use Vue3 `defaultComponent` structure

## [Demo](http://ramp4-app.azureedge.net/demo/users/sharvenp/vue3-legend-fixture/host/index.html)
## Steps to test:
No real steps to test, just toggle the visibility checkboxes and try to break it. 