### PR TITLE
Custom Details Templates

### DIFF
--- a/packages/ramp-core/docs/app/details.md
+++ b/packages/ramp-core/docs/app/details.md
@@ -14,23 +14,32 @@ The details fixture consists of three screens:
 
 If you don't want to use the provided templates for your layer results, you can create your own. The process is simple. All you need to do is create a Vue component and then add the layer-to-template binding to the RAMP configuration file.
 
-
 The example below explains how to create a basic template for the details panel.
 
 ### Example: Creating a Custom Template
 
-__1.__ The first thing you should do is create the Vue component that you want to use as the template. You can do this in various ways, but this example will make use of [Vue render functions](https://vuejs.org/v2/guide/render-function.html).
+__1.__ The first thing you should do is create the Vue component that you want to use as the template. You can do this in various ways, but this example will make use of template literals. If you need to include Javascript that contains more than a single expression, use the `methods` option, as shown below.
 
-
-To keep this example simple, the template created here will just display the name of the point when it is clicked on.
+To keep this example simple, the template created here will display the name of the point when it is clicked on and call a method to display the point's symbol, if it has one.
 
 ```javascript=
-RAMP.component('My_Custom_Component', {
-    props: ['identifyData'],
-    render: function(h) {
-        return h('div', [
-            h('span', 'The feature name is: ' + this.identifyData.data['name'])
-        ])
+rInstance.$element.component('My_Custom_Component', {
+        props: ['identifyData'],
+        template: `
+            <div>
+                <span>The feature name is: {{this.identifyData.data['name']}}</span>
+                <div v-html="displaySymbol()"/>
+            </div>
+        `,
+        methods: {
+            displaySymbol() {
+                if (this.identifyData.data['Symbol']) {
+                    return `
+                        <span>The feature symbol is: ${this.identifyData.data['Symbol']}</span>
+                    `;
+                }
+            }
+        }
     }
 });
 ```
@@ -41,7 +50,7 @@ __Note:__ it is important that you include the `identifyData` prop in the compon
 __2.__ Once the custom component has been created, you will want to add your layer to RAMP and set the new component as a custom template in the details fixture. You can do both of these in the configuration file:
 
 ```javascript=
-const myMap = new RAMP.Instance(document.getElementById("map"), {
+const rInstance = new RAMP.Instance(document.getElementById("map"), {
     map: { ... },
     layers: [
         {

--- a/packages/ramp-core/public/starter-scripts/panel-party.js
+++ b/packages/ramp-core/public/starter-scripts/panel-party.js
@@ -800,33 +800,31 @@ rInstance.$element.component('Water-Quantity-Template', {
     props: ['identifyData'],
     template: `
         <div style="align-items: center; justify-content: center; font-size: .875rem; font-family: Arial, sans-serif;">
-            ${renderHeader()}
-            ${createSection('Station ID', 'StationID')}
-            ${createSection('Province', 'E_Province')}
-            ${createSection('Report Year', 'Report_Year')}
+            <div v-html="renderHeader()" />
+            <div v-html="createSection('Station ID', 'StationID')" />
+            <div v-html="createSection('Province', 'E_Province')" />
+            <div v-html="createSection('Report Year', 'Report_Year')" />
             <div style="display: flex; flex-direction: row; color: #a0aec0; font-weight: bold; padding-top: 5px;">
-                <div style="flex: 1 1 0%; width: 100%;">,
-                    {{Latitude}}
+                <div style="flex: 1 1 0%; width: 100%;">
+                    Latitude
                 </div>
-                <div style="flex: 1 1 0%; width: 100%;">,
-                    {{Longitude}}
+                <div style="flex: 1 1 0%; width: 100%;">
+                    Longitude
                 </div>
             </div>
             <div style="display: flex; flex-direction: row;">
                 <div style="flex: 1 1 0%; width: 100%;">
-                    ${this.identifyData.data['Latitude']}
+                    {{this.identifyData.data['Latitude']}}
                 </div>
                 <div style="flex: 1 1 0%; width: 100%;">
-                    ${this.identifyData.data['Longitude']}
+                    {{this.identifyData.data['Longitude']}}
                 </div>
             </div>
             <div style="display: flex; flex-direction: column; padding-top: 5px; color: #4299e1;">
-                <span style="font-weight: bold; color: #a0aec0;">
-                    {{Links}}
-                    <span>${this.identifyData.data['E_DetailPageURL']}</span>
-                    <span>${this.identifyData.data['E_URL_Historical']}</span>
-                    <span>${this.identifyData.data['E_URL_RealTime']}</span>
-                </span>
+                <span style="font-weight: bold; color: #a0aec0;">Links</span>
+                <span v-html="this.identifyData.data['E_DetailPageURL']"></span>
+                <span v-html="this.identifyData.data['E_URL_Historical']"></span>
+                <span v-html="this.identifyData.data['E_URL_RealTime']"></span>
             </div>
         </div>
     `,
@@ -859,140 +857,6 @@ rInstance.$element.component('Water-Quantity-Template', {
             `;
         }
     }
-    // render: function(h) {
-    //     // Demonstrates that you can display different components in a template depending on an attribute value.
-    //     let renderHeader = () => {
-    //         if (this.identifyData.data['Symbol'] === '3') {
-    //             return h(
-    //                 'span',
-    //                 {
-    //                     style:
-    //                         'display: flex; font-size: 1.25rem; background-color: #e53e3e; color: white; padding: 4px; text-align: center;'
-    //                 },
-    //                 this.identifyData.data['StationName']
-    //             );
-    //         } else {
-    //             return h(
-    //                 'span',
-    //                 {
-    //                     style:
-    //                         'display: flex; font-size: 1.25rem; background-color: #3182ce; color: white; padding: 4px; text-align: center;'
-    //                 },
-    //                 this.identifyData.data['StationName']
-    //             );
-    //         }
-    //     };
-
-    //     let createSection = (title, id) => {
-    //         return h(
-    //             'div',
-    //             {
-    //                 style:
-    //                     'display: flex; flex-direction: column; font-size: .875rem; padding-top: 5px;'
-    //             },
-    //             [
-    //                 h(
-    //                     'span',
-    //                     {
-    //                         style: 'color: #a0aec0; font-weight: bold;'
-    //                     },
-    //                     title
-    //                 ),
-    //                 h('span', this.identifyData.data[id])
-    //             ]
-    //         );
-    //     };
-
-    //     return h(
-    //         'div',
-    //         {
-    //             style:
-    //                 'align-items: center; justify-content: center; font-size: .875rem; font-family: "Arial", sans-serif;'
-    //         },
-    //         [
-    //             renderHeader(),
-    //             createSection('Station ID', 'StationID'),
-    //             createSection('Province', 'E_Province'),
-    //             createSection('Report Year', 'Report_Year'),
-    //             h(
-    //                 'div',
-    //                 {
-    //                     style:
-    //                         'display: flex; flex-direction: row; color: #a0aec0; font-weight: bold; padding-top: 5px;'
-    //                 },
-    //                 [
-    //                     h(
-    //                         'div',
-    //                         {
-    //                             style: 'flex: 1 1 0%; width: 100%;'
-    //                         },
-    //                         'Latitude'
-    //                     ),
-    //                     h(
-    //                         'div',
-    //                         {
-    //                             style: 'flex: 1 1 0%; width: 100%;'
-    //                         },
-    //                         'Longitude'
-    //                     )
-    //                 ]
-    //             ),
-    //             h(
-    //                 'div',
-    //                 {
-    //                     style: 'display: flex; flex-direction: row;'
-    //                 },
-    //                 [
-    //                     h(
-    //                         'div',
-    //                         {
-    //                             style: 'flex: 1 1 0%; width: 100%;'
-    //                         },
-    //                         this.identifyData.data['Latitude']
-    //                     ),
-    //                     h(
-    //                         'div',
-    //                         {
-    //                             style: 'flex: 1 1 0%; width: 100%;'
-    //                         },
-    //                         this.identifyData.data['Longitude']
-    //                     )
-    //                 ]
-    //             ),
-    //             h(
-    //                 'div',
-    //                 {
-    //                     style:
-    //                         'display: flex; flex-direction: column; padding-top: 5px; color: #4299e1;'
-    //                 },
-    //                 [
-    //                     h(
-    //                         'span',
-    //                         {
-    //                             style: 'font-weight: bold; color: #a0aec0;'
-    //                         },
-    //                         'Links'
-    //                     ),
-    //                     h('span', {
-    //                         domProps: {
-    //                             innerHTML: this.identifyData.data['E_DetailPageURL']
-    //                         }
-    //                     }),
-    //                     h('span', {
-    //                         domProps: {
-    //                             innerHTML: this.identifyData.data['E_URL_Historical']
-    //                         }
-    //                     }),
-    //                     h('span', {
-    //                         domProps: {
-    //                             innerHTML: this.identifyData.data['E_URL_RealTime']
-    //                         }
-    //                     })
-    //                 ]
-    //             )
-    //         ]
-    //     );
-    // }
 });
 
 // start loading non-default fixtures; this is just an example

--- a/packages/ramp-core/public/starter-scripts/wms-layer.js
+++ b/packages/ramp-core/public/starter-scripts/wms-layer.js
@@ -68,8 +68,7 @@ let config = {
             {
                 id: 'GeoMet',
                 layerType: 'ogcWms',
-                url:
-                    'http://geo.weather.gc.ca/geomet/?lang=E&service=WMS&request=GetCapabilities',
+                url: 'http://geo.weather.gc.ca/geomet/?lang=E&service=WMS&request=GetCapabilities',
                 state: {
                     visibility: true,
                     opacity: 0.5
@@ -126,12 +125,13 @@ let options = {
     loadDefaultFixtures: false,
     loadDefaultEvents: true
 };
+rInstance = new RAMP.Instance(document.getElementById('app'), config, options);
 
-Vue.component('GeoMet-Template', {
+rInstance.$element.component('GeoMet-Template', {
     props: ['identifyData'],
-    render: function(h) {
-        if (!this.identifyData) return;
-        let parseText = text => {
+    template: `<div v-html="createTemplate()" />`,
+    methods: {
+        parseText(text) {
             let obj = {};
             let rx = /(\w+) = '(?:"([^"]*)"|([^']*))/g;
             while ((m = rx.exec(text)) !== null) {
@@ -142,103 +142,47 @@ Vue.component('GeoMet-Template', {
                 }
             }
             return obj;
-        };
-
-        let data = parseText(this.identifyData.data);
-
-        return h(
-            'div',
-            {
-                style:
-                    'align-items: center; justify-content: center; font-size: .875rem; font-family: "Arial", sans-serif;'
-            },
-            [
-                h(
-                    'span',
-                    {
-                        style:
-                            'display: flex; font-size: 1.25rem; background-color: #3182ce; color: white; padding: 4px; text-align: center;'
-                    },
-                    'GDPS.ETA_NT - Cloud Coverage (%)'
-                ),
-                h(
-                    'div',
-                    {
-                        style:
-                            'display: flex; flex-direction: column; font-size: .875rem; padding-top: 5px;'
-                    },
-                    [
-                        h(
-                            'span',
-                            {
-                                style: 'color: #a0aec0; font-weight: bold;'
-                            },
-                            'Coverage'
-                        ),
-                        h('span', data.value_0)
-                    ]
-                ),
-                h(
-                    'div',
-                    {
-                        style:
-                            'display: flex; flex-direction: row; color: #a0aec0; font-weight: bold; padding-top: 5px;'
-                    },
-                    [
-                        h(
-                            'div',
-                            {
-                                style: 'flex: 1 1 0%; width: 100%;'
-                            },
-                            'x'
-                        ),
-                        h(
-                            'div',
-                            {
-                                style: 'flex: 1 1 0%; width: 100%;'
-                            },
-                            'y'
-                        )
-                    ]
-                ),
-                h(
-                    'div',
-                    {
-                        style: 'display: flex; flex-direction: row;'
-                    },
-                    [
-                        h(
-                            'div',
-                            {
-                                style: 'flex: 1 1 0%; width: 100%;'
-                            },
-                            data.x
-                        ),
-                        h(
-                            'div',
-                            {
-                                style: 'flex: 1 1 0%; width: 100%;'
-                            },
-                            data.y
-                        )
-                    ]
-                )
-            ]
-        );
+        },
+        createTemplate() {
+            if (!this.identifyData) return;
+            let data = this.parseText(this.identifyData.data.data);
+            return `
+            <div style="align-items: center; justify-content: center; font-size: .875rem; font-family: Arial, sans-serif;">
+                <span style="display: flex; font-size: 1.25rem; background-color: #3182ce; color: white; padding: 4px; text-align: center;">
+                    GDPS.ETA_NT - Cloud Coverage (%)
+                </span>
+                <div style="display: flex; flex-direction: column; font-size: .875rem; padding-top: 5px;">
+                    <span style="color: #a0aec0; font-weight: bold;">
+                        Coverage
+                    </span>
+                    <span>
+                        ${data.value_0}
+                    </span>
+                </div>
+                <div style="display: flex; flex-direction: row; color: #a0aec0; font-weight: bold; padding-top: 5px;">
+                    <div style="flex: 1 1 0%; width: 100%;">
+                        x
+                    </div>
+                    <div style="flex: 1 1 0%; width: 100%;">
+                        y
+                    </div>
+                </div>
+                <div style="display: flex; flex-direction: row;">
+                    <div style="flex: 1 1 0%; width: 100%;">
+                        ${data.x}
+                    </div>
+                    <div style="flex: 1 1 0%; width: 100%;">
+                        ${data.y}
+                    </div>
+                </div>
+            </div>
+            `;
+        }
     }
 });
 
-rInstance = new RAMP.Instance(document.getElementById('app'), config, options);
 rInstance.fixture
-    .addDefaultFixtures([
-        'mapnav',
-        'legend',
-        'appbar',
-        'grid',
-        'details',
-        'wizard',
-        'export-v1'
-    ])
+    .addDefaultFixtures(['mapnav', 'legend', 'appbar', 'grid', 'details', 'wizard', 'export-v1'])
     .then(() => {
         rInstance.panel.open('legend-panel');
     });

--- a/packages/ramp-core/src/fixtures/details/item-screen.vue
+++ b/packages/ramp-core/src/fixtures/details/item-screen.vue
@@ -91,9 +91,7 @@ export default defineComponent({
          * Returns the information for a single identify result, given the layer and item offsets.
          */
         identifyItem(): any {
-            const p = this.payload[this.resultIndex!].items[this.itemIndex!];
-            console.log(p);
-            return p;
+            return this.payload[this.resultIndex!].items[this.itemIndex!];
         },
 
         itemName(): string {
@@ -115,10 +113,8 @@ export default defineComponent({
                 this.templateBindings[layer.id] &&
                 this.templateBindings[layer.id].template
             ) {
-                console.log('template is custom....', this.templateBindings[layer.id]);
                 return this.templateBindings[layer.id].template;
             }
-            console.log('the template is not custom...');
             // If nothing is found, use a default template.
             if (this.layerType === 'ogcWms') {
                 return 'html-default';

--- a/packages/ramp-core/src/main.ts
+++ b/packages/ramp-core/src/main.ts
@@ -4,7 +4,8 @@
 // when compiled using the `serve` command, the code is treated as an app, not a library,
 // so we need to expose RAMP API on the window manually
 import api from '@/api';
-import Vue from 'vue';
+//@ts-ignore
+import Vue from 'vue/dist/vue.esm-bundler.js';
 import '@/styles/main.css';
 
 // assign RAMP api to global variable


### PR DESCRIPTION
### Changes
- Convert details templates to use template literals instead of the `render()` function
    - Based on [this](https://v3.vuejs.org/guide/migration/render-function-api.html), it doesn't seem like we'll be able to use `render()` in the starter scripts anymore
 - Update details fixture docs
 - Get custom details templates to load when running locally (thanks to Spencer 🙏 )

### Demo
[panel-party](http://ramp4-app.azureedge.net/demo/users/elsa-huang/details-fixture/host/index-e2e.html?script=panel-party) has custom templates for `WFSLayer` and `WaterQuantity`
[wms-layer](http://ramp4-app.azureedge.net/demo/users/elsa-huang/details-fixture/host/index-e2e.html?script=wms-layer) has custom template for `GeoMet`