### PR TITLE
Fix client bounding rect errors and migrate appbar buttons and

### DIFF
--- a/packages/ramp-core/src/components/notification-center/appbar-button.vue
+++ b/packages/ramp-core/src/components/notification-center/appbar-button.vue
@@ -3,6 +3,7 @@
         :onClickFunction="onClick"
         :tooltip="$t('notifications.title')"
         class="notification-button"
+        id=""
     >
         <!-- https://fonts.google.com/icons?selected=Material%20Icons%3Anotifications -->
         <svg

--- a/packages/ramp-core/src/fixtures/appbar/api/appbar.ts
+++ b/packages/ramp-core/src/fixtures/appbar/api/appbar.ts
@@ -1,10 +1,6 @@
 import { FixtureInstance } from '@/api';
 
-import {
-    AppbarFixtureConfig,
-    AppbarItemInstance,
-    AppbarItemSet
-} from '../store';
+import { AppbarFixtureConfig, AppbarItemInstance, AppbarItemSet } from '../store';
 
 export class AppbarAPI extends FixtureInstance {
     /**
@@ -30,9 +26,7 @@ export class AppbarAPI extends FixtureInstance {
             return;
         }
 
-        const appbarItems = appbarConfig.items.map(
-            item => new AppbarItemInstance(item)
-        );
+        const appbarItems = appbarConfig.items.map(item => new AppbarItemInstance(item));
 
         // save appbar items as a collection to the store
         // they are saves as a set for easy by-id access
@@ -56,10 +50,7 @@ export class AppbarAPI extends FixtureInstance {
                     if (typeof item === 'string') {
                         return [`${item}-panel`, new AppbarItemInstance(item)];
                     }
-                    return [
-                        item.panelId,
-                        new AppbarItemInstance(item.appbarItem)
-                    ];
+                    return [item.panelId, new AppbarItemInstance(item.appbarItem)];
                 })
             );
             this.$vApp.$store.set('appbar/tempButtonDict', appbarTempItems);
@@ -79,28 +70,23 @@ export class AppbarAPI extends FixtureInstance {
             // appbar check components with the literal id and with a `-appbar-button` suffix;
             [`${id}-appbar-button`, id].some(v => {
                 // TODO: fix this if needed
-                // if (v in this.$vApp.$options.components!) {
-                // if an item is registered globally, save the name of the registered component
-                this.$vApp.$store.set(`appbar/items@${id}.componentId`, v);
-                // }
+                if (this.$iApi.fixture.get(v)) {
+                    // if an item is registered globally, save the name of the registered component
+                    this.$vApp.$store.set(`appbar/items@${id}.componentId`, v);
+                }
             });
         });
 
         // check the list of temp appbar buttons as well
-        const tempButtonDict = this.$vApp.$store.get<any>(
-            'appbar/tempButtonDict'
-        );
+        const tempButtonDict = this.$vApp.$store.get<any>('appbar/tempButtonDict');
         Object.keys(tempButtonDict).forEach(key => {
             const id = tempButtonDict[key].id;
             [`${id}-appbar-button`, id].some(v => {
                 // TODO: fix this if needed
-                // if (v in this.$vApp.$options.components!) {
-                // if an item is registered globally, save the name of the registered component
-                this.$vApp.$store.set(
-                    `appbar/tempButtonDict@${key}.componentId`,
-                    v
-                );
-                // }
+                if (this.$iApi.fixture.get(v)) {
+                    // if an item is registered globally, save the name of the registered component
+                    this.$vApp.$store.set(`appbar/tempButtonDict@${key}.componentId`, v);
+                }
             });
         });
     }

--- a/packages/ramp-core/src/fixtures/appbar/appbar.vue
+++ b/packages/ramp-core/src/fixtures/appbar/appbar.vue
@@ -6,7 +6,7 @@
     >
         <component
             v-for="(item, index) in items"
-            :is="item.componentId"
+            :is="addComponentIdSuffix(item.componentId)"
             :key="`${item}-${index}`"
             class="appbar-item"
             :class="{ 'h-48': item.id !== 'divider' }"
@@ -16,7 +16,7 @@
         <divider class="appbar-item"></divider>
         <component
             v-for="item in temporaryItems"
-            :is="item.componentId"
+            :is="addComponentIdSuffix(item.componentId)"
             :key="`${item.id}-temp`"
             class="appbar-item h-48"
             :options="item.options"
@@ -38,19 +38,13 @@ import { get } from '@/store/pathify-helper';
 import MoreAppbarButtonV from './more-button.vue';
 import NavAppbarButtonV from './nav-button.vue';
 import NotificationsAppbarButtonV from '@/components/notification-center/appbar-button.vue';
-import LegendAppbarButtonV from '@/fixtures/legend/appbar-button.vue';
-import BasemapAppbarButtonV from '@/fixtures/basemap/appbar-button.vue';
-import GeosearchAppbarButtonV from '@/fixtures/geosearch/appbar-button.vue';
 
 export default defineComponent({
     name: 'AppbarV',
     components: {
         'more-button': MoreAppbarButtonV,
         'nav-button': NavAppbarButtonV,
-        'notifications-appbar-button': NotificationsAppbarButtonV,
-        legend: LegendAppbarButtonV,
-        basemap: BasemapAppbarButtonV,
-        geosearch: GeosearchAppbarButtonV
+        'notifications-appbar-button': NotificationsAppbarButtonV
     },
 
     data() {
@@ -62,7 +56,6 @@ export default defineComponent({
             overflow: false
         };
     },
-    // TODO: update this after (issue with getBoundingClientRect)
     updated() {
         this.$nextTick(() => {
             const element: any = this.$refs.el;
@@ -117,6 +110,18 @@ export default defineComponent({
                 if (dropdown.childElementCount == 0) this.overflow = false;
             }
         });
+    },
+    methods: {
+        /**
+         * Checks if the component id has the "-appbar-button" suffix
+         * Returns the component id with the suffix added
+         */
+        addComponentIdSuffix(componentId: string): string {
+            if (componentId.includes('-appbar-button')) {
+                return componentId;
+            }
+            return `${componentId}-appbar-button`;
+        }
     }
 });
 </script>

--- a/packages/ramp-core/src/fixtures/appbar/appbar.vue
+++ b/packages/ramp-core/src/fixtures/appbar/appbar.vue
@@ -2,6 +2,7 @@
     <div
         class="absolute top-0 left-0 bottom-28 z-50 flex flex-col items-stretch w-40 pointer-events-auto appbar bg-black-75 sm:w-64"
         v-focus-list
+        ref="el"
     >
         <component
             v-for="(item, index) in items"
@@ -31,12 +32,8 @@
 </template>
 
 <script lang="ts">
-import { ComputedRef, defineComponent } from 'vue';
-import { Vue, Options } from 'vue-property-decorator';
-import { Get } from 'vuex-pathify';
+import { defineComponent, ref } from 'vue';
 import { get } from '@/store/pathify-helper';
-
-import { AppbarItemInstance } from './store';
 
 import MoreAppbarButtonV from './more-button.vue';
 import NavAppbarButtonV from './nav-button.vue';
@@ -64,67 +61,63 @@ export default defineComponent({
             // @Get('appbar/temporary') temporaryItems!: AppbarItemInstance[];
             overflow: false
         };
-    }
-
+    },
     // TODO: update this after (issue with getBoundingClientRect)
-    // updated() {
-    //     let children: Element[] = [...this.$el.childNodes];
-    //     console.log('appbar updated: ', this);
-    //     let bound:
-    //         | number
-    //         | undefined = this.$el.lastChild?.getBoundingClientRect().top;
-    //     let dropdown: Element | null = document.getElementById('dropdown');
+    updated() {
+        this.$nextTick(() => {
+            const element: any = this.$refs.el;
 
-    //     // check positions of appbar buttons
-    //     for (let i = children.length - 3; i >= 0; i--) {
-    //         if (
-    //             bound &&
-    //             dropdown &&
-    //             (children[i].getBoundingClientRect().bottom >= bound ||
-    //                 (this.overflow &&
-    //                     children[i].getBoundingClientRect().bottom + 48 >=
-    //                         bound))
-    //         ) {
-    //             children[i].classList.remove(
-    //                 'hover:text-white',
-    //                 'text-gray-400'
-    //             );
-    //             children[i].classList.add('text-black', 'hover:bg-gray-100');
+            let children: Element[] = [...element.childNodes];
+            console.log('appbar updated: ', this);
 
-    //             this.$el.removeChild(children[i]);
-    //             dropdown.appendChild(children[i]);
-    //             if (!this.overflow) this.overflow = true;
-    //         } else {
-    //             break;
-    //         }
-    //     }
+            let bound: number | undefined = children[children.length - 2].clientTop;
+            let dropdown: Element | null = document.getElementById('dropdown');
 
-    //     // check position of more button
-    //     let more: Element | null = document.getElementById('more');
-    //     if (
-    //         this.overflow &&
-    //         bound &&
-    //         more &&
-    //         dropdown &&
-    //         more.getBoundingClientRect().bottom !== 0 &&
-    //         (more.getBoundingClientRect().bottom <= bound - 48 ||
-    //             dropdown.childElementCount == 1)
-    //     ) {
-    //         while (
-    //             more.getBoundingClientRect().bottom <= bound - 48 ||
-    //             dropdown.childElementCount == 1
-    //         ) {
-    //             //@ts-ignore
-    //             let item: Element = dropdown.firstElementChild;
-    //             item.classList.remove('text-black', 'hover:bg-gray-100');
-    //             item.classList.add('text-gray-400', 'hover:text-white');
+            // check positions of appbar buttons
+            for (let i = children.length - 3; i >= 0; i--) {
+                let bottom: number = children[i].clientTop + children[i].clientHeight;
+                if (
+                    bound &&
+                    dropdown &&
+                    (bottom >= bound || (this.overflow && bottom + 48 >= bound))
+                ) {
+                    console.log(`[${i}]`, children[i].getBoundingClientRect());
 
-    //             dropdown.removeChild(item);
-    //             this.$el.insertBefore(item, more);
-    //         }
-    //         if (dropdown.childElementCount == 0) this.overflow = false;
-    //     }
-    // }
+                    children[i].classList.remove('hover:text-white', 'text-gray-400');
+                    children[i].classList.add('text-black', 'hover:bg-gray-100');
+
+                    element.removeChild(children[i]);
+                    dropdown.appendChild(children[i]);
+                    if (!this.overflow) this.overflow = true;
+                } else {
+                    break;
+                }
+            }
+
+            // check position of more button
+            let more: Element | null = document.getElementById('more');
+            let moreBottom = element.clientTop + element.clientHeight;
+            if (
+                this.overflow &&
+                bound &&
+                more &&
+                dropdown &&
+                moreBottom !== 0 &&
+                (moreBottom <= bound - 48 || dropdown.childElementCount == 1)
+            ) {
+                while (moreBottom <= bound - 48 || dropdown.childElementCount == 1) {
+                    let item: Element | null = dropdown.firstElementChild;
+                    if (item) {
+                        item.classList.remove('text-black', 'hover:bg-gray-100');
+                        item.classList.add('text-gray-400', 'hover:text-white');
+                        dropdown.removeChild(item);
+                        element.insertBefore(item, more);
+                    }
+                }
+                if (dropdown.childElementCount == 0) this.overflow = false;
+            }
+        });
+    }
 });
 </script>
 

--- a/packages/ramp-core/src/fixtures/appbar/button.vue
+++ b/packages/ramp-core/src/fixtures/appbar/button.vue
@@ -19,7 +19,6 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { Vue, Prop } from 'vue-property-decorator';
 
 export default defineComponent({
     name: 'AppbarButtonV',

--- a/packages/ramp-core/src/fixtures/appbar/divider.vue
+++ b/packages/ramp-core/src/fixtures/appbar/divider.vue
@@ -4,7 +4,6 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-
 export default defineComponent({
     name: 'DividerV'
 });

--- a/packages/ramp-core/src/fixtures/appbar/more-button.vue
+++ b/packages/ramp-core/src/fixtures/appbar/more-button.vue
@@ -32,7 +32,6 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { Vue, Prop } from 'vue-property-decorator';
 
 export default defineComponent({
     name: 'MoreAppbarButtonV',

--- a/packages/ramp-core/src/fixtures/appbar/nav-button.vue
+++ b/packages/ramp-core/src/fixtures/appbar/nav-button.vue
@@ -43,10 +43,14 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { Vue } from 'vue-property-decorator';
+// this should not need to be imported
+import DropdownMenuV from '@/components/controls/dropdown-menu.vue';
 
 export default defineComponent({
     name: 'NavAppbarButtonV',
+    components: {
+        'dropdown-menu': DropdownMenuV
+    },
     methods: {
         exportToggle() {
             this.$iApi.panel.toggle('export-v1-panel');

--- a/packages/ramp-core/src/fixtures/appbar/nav-button.vue
+++ b/packages/ramp-core/src/fixtures/appbar/nav-button.vue
@@ -43,14 +43,9 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-// this should not need to be imported
-import DropdownMenuV from '@/components/controls/dropdown-menu.vue';
 
 export default defineComponent({
     name: 'NavAppbarButtonV',
-    components: {
-        'dropdown-menu': DropdownMenuV
-    },
     methods: {
         exportToggle() {
             this.$iApi.panel.toggle('export-v1-panel');

--- a/packages/ramp-core/src/fixtures/details/appbar-button.vue
+++ b/packages/ramp-core/src/fixtures/details/appbar-button.vue
@@ -1,5 +1,5 @@
 <template>
-    <appbar-button :onClickFunction="onClick" :tooltip="$t('details.title')" :iApi="iApi">
+    <appbar-button :onClickFunction="onClick" :tooltip="$t('details.title')">
         <!-- https://fonts.google.com/icons?selected=Material+Icons:place -->
         <svg
             class="fill-current w-24 h-24 ml-8 sm:ml-20"
@@ -15,18 +15,12 @@
 </template>
 <script lang="ts">
 import { defineComponent } from 'vue';
-import AppbarButtonV from '@/fixtures/appbar/button.vue';
 
 export default defineComponent({
     name: 'DetailsAppbarButtonV',
-    props: ['t', 'iApi'],
-    components: {
-        'appbar-button': AppbarButtonV
-    },
     methods: {
         onClick() {
-            console.log('TOGLIG');
-            this.$iApi.panel.toggle('details-panel');
+            this.$iApi.panel.toggleMinimize('details-panel');
         }
     }
 });

--- a/packages/ramp-core/src/fixtures/details/appbar-button.vue
+++ b/packages/ramp-core/src/fixtures/details/appbar-button.vue
@@ -1,5 +1,5 @@
 <template>
-    <appbar-button :onClickFunction="onClick" :tooltip="$t('details.title')">
+    <appbar-button :onClickFunction="onClick" :tooltip="$t('details.title')" :iApi="iApi">
         <!-- https://fonts.google.com/icons?selected=Material+Icons:place -->
         <svg
             class="fill-current w-24 h-24 ml-8 sm:ml-20"
@@ -14,13 +14,22 @@
     </appbar-button>
 </template>
 <script lang="ts">
-import { Vue } from 'vue-property-decorator';
+import { defineComponent } from 'vue';
+import AppbarButtonV from '@/fixtures/appbar/button.vue';
 
-export default class DetailsAppbarButtonV extends Vue {
-    onClick() {
-        this.$iApi.panel.toggleMinimize('details-panel');
+export default defineComponent({
+    name: 'DetailsAppbarButtonV',
+    props: ['t', 'iApi'],
+    components: {
+        'appbar-button': AppbarButtonV
+    },
+    methods: {
+        onClick() {
+            console.log('TOGLIG');
+            this.$iApi.panel.toggle('details-panel');
+        }
     }
-}
+});
 </script>
 
 <style lang="scss" scoped></style>

--- a/packages/ramp-core/src/fixtures/export-v1/appbar-button.vue
+++ b/packages/ramp-core/src/fixtures/export-v1/appbar-button.vue
@@ -1,8 +1,5 @@
 <template>
-    <appbar-button
-        :onClickFunction="onClick"
-        :tooltip="$t('export-v1.appbarButton')"
-    >
+    <appbar-button :onClickFunction="onClick" :tooltip="$t('export-v1.appbarButton')">
         <!-- https://fonts.google.com/icons?selected=Material+Icons:layers&icon.query=export -->
         <svg
             class="fill-current w-24 h-24 ml-8 sm:ml-20"
@@ -15,15 +12,16 @@
     </appbar-button>
 </template>
 <script lang="ts">
-import { Vue, Prop } from 'vue-property-decorator';
+import { defineComponent } from 'vue';
 
-export default class ExportV1AppbarButtonV extends Vue {
-    @Prop({ default: { colour: 'auto' } }) options!: { colour: string };
-
-    onClick() {
-        this.$iApi.panel.toggle('export-v1-panel');
+export default defineComponent({
+    name: 'ExportV1AppbarButtonV',
+    methods: {
+        onClick() {
+            this.$iApi.panel.toggle('export-v1-panel');
+        }
     }
-}
+});
 </script>
 
 <style lang="scss" scoped></style>

--- a/packages/ramp-core/src/fixtures/gazebo/appbar-button.vue
+++ b/packages/ramp-core/src/fixtures/gazebo/appbar-button.vue
@@ -4,15 +4,17 @@
     </appbar-button>
 </template>
 <script lang="ts">
-import { Vue, Prop } from 'vue-property-decorator';
+import { defineComponent } from 'vue';
 
-export default class GazeboAppbarButtonV extends Vue {
-    @Prop({ default: { colour: 'auto' } }) options!: { colour: string };
-
-    onClick() {
-        this.$iApi.panel.toggle({ id: 'p2', screen: 'p-2-screen-2' });
+export default defineComponent({
+    name: 'GazeboAppbarButtonV',
+    props: ['options'],
+    methods: {
+        onClick() {
+            this.$iApi.panel.toggle({ id: 'p2', screen: 'p-2-screen-2' });
+        }
     }
-}
+});
 </script>
 
 <style lang="scss" scoped></style>

--- a/packages/ramp-core/src/fixtures/metadata/appbar-button.vue
+++ b/packages/ramp-core/src/fixtures/metadata/appbar-button.vue
@@ -14,13 +14,16 @@
     </appbar-button>
 </template>
 <script lang="ts">
-import { Vue } from 'vue-property-decorator';
+import { defineComponent } from 'vue';
 
-export default class MetadataAppbarButtonV extends Vue {
-    onClick() {
-        this.$iApi.panel.toggleMinimize('metadata-panel');
+export default defineComponent({
+    name: 'MetadataAppbarButtonV',
+    methods: {
+        onClick() {
+            this.$iApi.panel.toggleMinimize('metadata-panel');
+        }
     }
-}
+});
 </script>
 
 <style lang="scss" scoped></style>

--- a/packages/ramp-core/src/fixtures/settings/appbar-button.vue
+++ b/packages/ramp-core/src/fixtures/settings/appbar-button.vue
@@ -16,13 +16,16 @@
     </appbar-button>
 </template>
 <script lang="ts">
-import { Vue } from 'vue-property-decorator';
+import { defineComponent } from 'vue';
 
-export default class SettingsAppbarButtonV extends Vue {
-    onClick() {
-        this.$iApi.panel.toggleMinimize('settings-panel');
+export default defineComponent({
+    name: 'SettingsAppbarButtonV',
+    methods: {
+        onClick() {
+            this.$iApi.panel.toggleMinimize('settings-panel');
+        }
     }
-}
+});
 </script>
 
 <style lang="scss" scoped></style>

--- a/packages/ramp-core/src/fixtures/snowman/appbar-button.vue
+++ b/packages/ramp-core/src/fixtures/snowman/appbar-button.vue
@@ -4,16 +4,19 @@
     </appbar-button>
 </template>
 <script lang="ts">
-import { Vue } from 'vue-property-decorator';
+import { defineComponent } from 'vue';
 
-export default class SnowmanAppbarButtonV extends Vue {
-    togglePanel(): void {
-        // summon the SNOWMAN!
-        this.$iApi.fixture.add('snowman');
+export default defineComponent({
+    name: 'SnowmanAppbarButtonV',
+    methods: {
+        togglePanel(): void {
+            // summon the SNOWMAN!
+            this.$iApi.fixture.add('snowman');
 
-        // the above will re-add the snowman fixture as it was self-terminated
+            // the above will re-add the snowman fixture as it was self-terminated
+        }
     }
-}
+});
 </script>
 
 <style lang="scss" scoped></style>


### PR DESCRIPTION
## Changes in this PR
- [FIX] Replaced `getBoundingClientRect` calls with `clientTop`, `clientWidth`, etc. properties
- [FIX] Temporary appbar buttons now show up when the panel is opened
- [FIX] Refactored some of the appbar button components to use `defineComponent`

## Steps to test
[Demo - RAMP Starter](http://ramp4-app.azureedge.net/demo/users/sharvenp/vue3-appbar-fixture/host/index.html)
[Demo - Panel Party](http://ramp4-app.azureedge.net/demo/users/sharvenp/vue3-appbar-fixture/host/index-e2e.html?script=panel-party)

RAMP Starter:
1. Load Demo
2. Click on the map once it loads - a map pin button should show up in the appbar
3. Close the details panel - the button should disappear
4. Open the grid of a layer - the grid button show appear in the appbar
5. Close the grid - the button should dissappear

Panel Party:
_Note: The snowman and gazebo buttons will not show up because their fixtures are never added. Hence there will be this empty space:_
How should we deal with this case?
<p align="center"><img src="https://user-images.githubusercontent.com/34178949/131693193-226e681c-12ce-4752-9113-87401c0c468c.png" /></p>

1. Load Demo
2. Open layer metadata and settings - their corresponding buttons should show up in the appbar
3. Close these panels - the buttons should dissappear

There also shouldn't be any errors regarding `getBoundingClientRect`. 