### PR TITLE
fix tippy animations + styling on caption bar

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -72,6 +72,7 @@ importers:
       terraformer-arcgis-parser: 1.1.0
       throttle-debounce: ~3.0.1
       tiny-emitter: ^2.1.0
+      tippy.js: next
       tslib: ~1.10.0
       tslint: 5.17.0
       tslint-loader: 3.6.0
@@ -118,6 +119,7 @@ importers:
       terraformer-arcgis-parser: 1.1.0
       throttle-debounce: 3.0.1
       tiny-emitter: 2.1.0
+      tippy.js: 6.0.0-alpha.0
       vue: 3.1.5
       vue-class-component: 8.0.0-rc.1_vue@3.1.5
       vue-i18n: 9.1.7_vue@3.1.5
@@ -13662,6 +13664,12 @@ packages:
 
   /tiny-emitter/2.1.0:
     resolution: {integrity: sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==}
+    dev: false
+
+  /tippy.js/6.0.0-alpha.0:
+    resolution: {integrity: sha512-jdWKStAr8DKc5o+N2OUddqJMW4UFCIe/U6Ki8nSoE1WqQ9UYrq4ekO2kxMea75edsIuYy0cWfdb1Iop9lIHDLw==}
+    dependencies:
+      '@popperjs/core': 2.9.3
     dev: false
 
   /tippy.js/6.3.1:

--- a/packages/ramp-core/package.json
+++ b/packages/ramp-core/package.json
@@ -46,6 +46,7 @@
         "vue-property-decorator": "^10.0.0-rc.2",
         "vue-slider-component": "next",
         "vue-tippy": "next",
+        "tippy.js": "next",
         "vuex": "^4.0.0",
         "vuex-pathify": "~1.4.1",
         "webpack": "4.41.3",

--- a/packages/ramp-core/src/app.vue
+++ b/packages/ramp-core/src/app.vue
@@ -5,22 +5,21 @@
 </template>
 
 <script lang="ts">
-import { Vue, Options } from 'vue-class-component';
-
+import { defineComponent } from 'vue';
 import Shell from '@/components/shell.vue';
 
 import ro from '@/scripts/resize-observer.js';
+import 'tippy.js/animations/scale.css';
 
 //TOOLTIPS
 //@ts-ignore
-import VueTippy, { setDefaultProps, tippy } from 'vue-tippy';
+import { setDefaultProps } from 'vue-tippy';
 
-@Options({
+export default defineComponent({
     components: {
         Shell
-    }
-})
-export default class App extends Vue {
+    },
+
     mounted() {
         // let ResizeObserver observe the app div
         // it applies 'xs' 'sm' 'md' and 'lg' classes to the div depending on the size
@@ -34,6 +33,7 @@ export default class App extends Vue {
             },
             // a11y: false, // can't find a replacement for Vue 3
             theme: 'ramp4',
+            animation: 'scale',
             inertia: true,
             trigger: 'mouseenter manual focus',
             // needed to have tooltips in fullscreen, by default it appends to document.body
@@ -43,7 +43,7 @@ export default class App extends Vue {
         let parent = this.$el.parentElement;
         parent?.style.setProperty('overflow', 'hidden');
     }
-}
+});
 </script>
 
 <style lang="scss">

--- a/packages/ramp-core/src/components/controls/dropdown-menu.vue
+++ b/packages/ramp-core/src/components/controls/dropdown-menu.vue
@@ -4,7 +4,11 @@
             class="text-gray-500 hover:text-black dropdown-button"
             @click="open = !open"
             :content="tooltip"
-            v-tippy="{ placement: tooltipPlacement }"
+            v-tippy="{
+                placement: tooltipPlacement,
+                theme: tooltipTheme,
+                animation: tooltipAnimation
+            }"
             ref="dropdown-trigger"
         >
             <slot name="header"></slot>
@@ -29,6 +33,8 @@ export default class DropdownMenuV extends Vue {
     @Prop({ default: 'bottom' }) position!: Placement;
     @Prop() tooltip?: string;
     @Prop({ default: 'bottom' }) tooltipPlacement?: string;
+    @Prop({ default: 'ramp4' }) tooltipTheme?: string;
+    @Prop({ default: 'scale' }) tooltipAnimation?: string;
 
     open: boolean = false;
     popper: any;

--- a/packages/ramp-core/src/components/map/map-caption.vue
+++ b/packages/ramp-core/src/components/map/map-caption.vue
@@ -55,7 +55,7 @@
             @click="onScaleClick"
             :aria-pressed="scale.isImperialScale"
             :aria-label="$t('map.toggleScaleUnits')"
-            v-tippy="{ placement: 'top', hideOnClick: false }"
+            v-tippy="{ placement: 'top', hideOnClick: false, theme: 'ramp4', animation: 'scale' }"
             :content="$t('map.toggleScaleUnits')"
         >
             <span
@@ -101,9 +101,7 @@
 </template>
 
 <script lang="ts">
-import { ComputedRef } from 'vue';
-import { Vue, Options } from 'vue-property-decorator';
-import { Get } from 'vuex-pathify';
+import { defineComponent } from 'vue';
 import { get } from '@/store/pathify-helper';
 import { Attribution, ScaleBarProperties } from '@/geo/api';
 import { GlobalEvents } from '@/api';
@@ -111,19 +109,19 @@ import { MapCaptionStore } from '@/store/modules/map-caption';
 
 import NotificationsCaptionButtonV from '@/components/notification-center/caption-button.vue';
 
-@Options({
+export default defineComponent({
+    data() {
+        return {
+            scale: get(MapCaptionStore.scale),
+            attribution: get(MapCaptionStore.attribution),
+            cursorCoords: get(MapCaptionStore.cursorCoords),
+            lang: [] as string[]
+        };
+    },
+
     components: {
         'notifications-caption-button': NotificationsCaptionButtonV
-    }
-})
-export default class MapCaptionV extends Vue {
-    scale: ComputedRef<ScaleBarProperties> = get(MapCaptionStore.scale);
-    attribution: ComputedRef<Attribution> = get(MapCaptionStore.attribution);
-    cursorCoords: ComputedRef<string> = get(MapCaptionStore.cursorCoords);
-    // @Get(MapCaptionStore.scale) scale!: ScaleBarProperties;
-    // @Get(MapCaptionStore.attribution) attribution!: Attribution;
-    // @Get(MapCaptionStore.cursorCoords) cursorCoords!: string;
-    lang: string[] = [];
+    },
 
     mounted() {
         // When map is created update scale
@@ -141,31 +139,35 @@ export default class MapCaptionV extends Vue {
         this.$iApi.event.on(GlobalEvents.MAP_CREATED, () => {
             this.$iApi.geo.map.caption.updateScale();
         });
-    }
+    },
 
     updated() {
-        if (this.$iApi.$vApp.$i18n && this.lang.length == 0) {
-            this.lang = this.$iApi.$vApp.$i18n.availableLocales;
+        this.$nextTick(function() {
+            if (this.$iApi.$vApp.$i18n && this.lang.length == 0) {
+                this.lang = this.$iApi.$vApp.$i18n.availableLocales;
+            }
+        });
+    },
+
+    methods: {
+        changeLang(lang: string) {
+            if (this.$iApi.$vApp.$i18n.locale != lang) {
+                this.$iApi.setLanguage(lang);
+            }
+        },
+
+        /**
+         * Toggle the scale units
+         */
+        onScaleClick() {
+            this.$iApi.$vApp.$store.set(MapCaptionStore.toggleScale, {});
+            this.$iApi.geo.map.caption.updateScale();
         }
     }
-
-    changeLang(lang: string) {
-        if (this.$iApi.$vApp.$i18n.locale != lang) {
-            this.$iApi.setLanguage(lang);
-        }
-    }
-
-    /**
-     * Toggle the scale units
-     */
-    onScaleClick() {
-        this.$iApi.$vApp.$store.set(MapCaptionStore.toggleScale, {});
-        this.$iApi.geo.map.caption.updateScale();
-    }
-}
+});
 </script>
 
-<style lang="scss" scoped>
+<style lang="scss">
 .map-caption {
     backdrop-filter: blur(5px);
 }

--- a/packages/ramp-core/src/components/notification-center/caption-button.vue
+++ b/packages/ramp-core/src/components/notification-center/caption-button.vue
@@ -35,7 +35,7 @@
                             @click="clearAll"
                             class="text-gray-500 hover:text-black p-4 mr-6"
                             :content="$t('notifications.controls.clearAll')"
-                            v-tippy="{ placement: 'bottom' }"
+                            v-tippy="{ placement: 'bottom', theme: 'ramp4', animation: 'scale' }"
                         >
                             <!-- https://fonts.google.com/icons?selected=Material%20Icons%3Aclear_all -->
                             <svg

--- a/packages/ramp-core/src/components/notification-center/notification-item.vue
+++ b/packages/ramp-core/src/components/notification-center/notification-item.vue
@@ -2,7 +2,7 @@
     <li
         class="flex-col default-focus-style px-4"
         :content="$t(open ? 'notifications.controls.collapse' : 'notifications.controls.expand')"
-        v-tippy="{ onShow: tooltipShow }"
+        v-tippy="{ onShow: tooltipShow, theme: 'ramp4', animation: 'scale' }"
         @click="open = !open"
         :class="notification.messageList ? 'cursor-pointer' : ''"
     >
@@ -27,7 +27,7 @@
                 @click.stop="removeNotification(notification)"
                 class="mx-4 p-4"
                 :content="$t('notifications.controls.dismiss')"
-                v-tippy
+                v-tippy="{ theme: 'ramp4', animation: 'scale' }"
             >
                 <svg
                     class="fill-current w-16 h-16"
@@ -77,4 +77,4 @@ export default class NotificationListV extends Vue {
 }
 </script>
 
-<style lang="scss" scoped></style>
+<style lang="scss"></style>

--- a/packages/ramp-core/src/components/notification-center/screen.vue
+++ b/packages/ramp-core/src/components/notification-center/screen.vue
@@ -16,7 +16,7 @@
                         @click="clearAll"
                         class="text-gray-500 hover:text-black p-4 ml-auto"
                         :content="$t('notifications.controls.clearAll')"
-                        v-tippy="{ placement: 'bottom' }"
+                        v-tippy="{ placement: 'bottom', theme: 'ramp4', animation: 'scale' }"
                     >
                         <!-- https://fonts.google.com/icons?selected=Material%20Icons%3Aclear_all -->
                         <svg
@@ -59,4 +59,4 @@ export default class NotificationsScreenV extends Vue {
 }
 </script>
 
-<style lang="scss" scoped></style>
+<style lang="scss"></style>

--- a/packages/ramp-core/src/components/panel-stack/controls/back.vue
+++ b/packages/ramp-core/src/components/panel-stack/controls/back.vue
@@ -4,7 +4,7 @@
             class="text-gray-500 hover:text-black p-8"
             :class="{ 'text-gray-700': active }"
             :content="$t('panels.controls.back')"
-            v-tippy="{ placement: 'bottom' }"
+            v-tippy="{ placement: 'bottom', theme: 'ramp4', animation: 'scale' }"
         >
             <svg
                 xmlns="http://www.w3.org/2000/svg"

--- a/packages/ramp-core/src/components/panel-stack/controls/close.vue
+++ b/packages/ramp-core/src/components/panel-stack/controls/close.vue
@@ -4,7 +4,7 @@
             class="text-gray-500 hover:text-black p-8"
             :class="{ 'text-gray-700': active }"
             :content="$t('panels.controls.close')"
-            v-tippy="{ placement: 'bottom' }"
+            v-tippy="{ placement: 'bottom', theme: 'ramp4', animation: 'scale' }"
         >
             <svg
                 class="fill-current w-16 h-16"

--- a/packages/ramp-core/src/components/panel-stack/controls/minimize.vue
+++ b/packages/ramp-core/src/components/panel-stack/controls/minimize.vue
@@ -4,7 +4,7 @@
             class="text-gray-500 hover:text-black p-6"
             :class="{ 'text-gray-700': active }"
             :content="$t('panels.controls.minimize')"
-            v-tippy="{ placement: 'bottom' }"
+            v-tippy="{ placement: 'bottom', theme: 'ramp4', animation: 'scale' }"
         >
             <svg
                 class="fill-current w-20 h-20"

--- a/packages/ramp-core/src/styles/main.css
+++ b/packages/ramp-core/src/styles/main.css
@@ -90,8 +90,3 @@
 .tippy-box[data-theme~='ramp4'] svg {
     display: inline;
 }
-
-.tippy-box[data-inertia][data-state='visible'] {
-    transition-timing-function: cubic-bezier(0.165, 0.84, 0.44, 1);
-    transition-duration: 300ms;
-}


### PR DESCRIPTION
**Changes in this PR**
- tippy animations should now work as they did in Vue 2
- tooltips in the caption bar (at the bottom) should now have a style and animation
- converted a few more components to use `defineComponent` (map-caption.vue, app.vue)

**Concerns**
None :)

**Testing this PR**
You can find a demo for this PR [here](http://ramp4-app.azureedge.net/demo/users/RyanCoulsonCA/vue3-tippy-animations/host/index.html).

To test, simply hover over anything that should have a tooltip. It should look just like how it did in the Vue 2 version. Also, hover over components in the caption bar and ensure that they are styled properly.