### PR TITLE
fix ag-grid prop errors

### DIFF
--- a/packages/ramp-core/src/fixtures/grid/index.ts
+++ b/packages/ramp-core/src/fixtures/grid/index.ts
@@ -1,5 +1,6 @@
 import { GridAPI } from './api/grid';
 import { grid } from './store/index';
+import { markRaw } from 'vue';
 
 import GridScreenV from './screen.vue';
 import GridAppbarButtonV from './appbar-button.vue';
@@ -12,7 +13,7 @@ class GridFixture extends GridAPI {
             {
                 'grid-panel': {
                     screens: {
-                        'grid-screen': GridScreenV
+                        'grid-screen': markRaw(GridScreenV)
                     },
                     style: {
                         'flex-grow': '1',

--- a/packages/ramp-core/src/fixtures/grid/templates/custom-date-filter.vue
+++ b/packages/ramp-core/src/fixtures/grid/templates/custom-date-filter.vue
@@ -26,9 +26,9 @@ import { defineComponent } from 'vue';
 
 export default defineComponent({
     name: 'GridCustomDateFilterV',
-    props: ['params'],
-    data() {
+    data(props) {
         return {
+            params: props.params as any,
             minVal: '' as any,
             maxVal: '' as any
         };

--- a/packages/ramp-core/src/fixtures/grid/templates/custom-header.vue
+++ b/packages/ramp-core/src/fixtures/grid/templates/custom-header.vue
@@ -93,10 +93,9 @@ import { defineComponent } from 'vue';
 
 export default defineComponent({
     name: 'GridCustomHeaderV',
-    props: ['params'],
-
-    data() {
+    data(props) {
         return {
+            params: props.params as any,
             sort: 0 as number,
             sortable: false as boolean,
             canMoveLeft: false as boolean,

--- a/packages/ramp-core/src/fixtures/grid/templates/custom-number-filter.vue
+++ b/packages/ramp-core/src/fixtures/grid/templates/custom-number-filter.vue
@@ -24,10 +24,9 @@ import { defineComponent } from 'vue';
 
 export default defineComponent({
     name: 'GridCustomNumberFilterV',
-    props: ['params'],
-
-    data() {
+    data(props) {
         return {
+            params: props.params as any,
             minVal: '' as any,
             maxVal: '' as any
         };

--- a/packages/ramp-core/src/fixtures/grid/templates/custom-selector-filter.vue
+++ b/packages/ramp-core/src/fixtures/grid/templates/custom-selector-filter.vue
@@ -13,9 +13,9 @@ import { defineComponent, ref } from 'vue';
 
 export default defineComponent({
     name: 'GridCustomSelectorFilterV',
-    props: ['params'],
-    data() {
+    data(props) {
         return {
+            params: props.params as any,
             selectedOption: '' as String,
             options: [] as Array<String>
         };

--- a/packages/ramp-core/src/fixtures/grid/templates/custom-text-filter.vue
+++ b/packages/ramp-core/src/fixtures/grid/templates/custom-text-filter.vue
@@ -15,9 +15,9 @@ import { defineComponent, ref } from 'vue';
 
 export default defineComponent({
     name: 'GridCustomTextFilterV',
-    props: ['params'],
-    data() {
+    data(props) {
         return {
+            params: props.params as any,
             filterValue: ''
         };
     },

--- a/packages/ramp-core/src/fixtures/grid/templates/details-button-renderer.vue
+++ b/packages/ramp-core/src/fixtures/grid/templates/details-button-renderer.vue
@@ -28,8 +28,11 @@ import { GlobalEvents } from '@/api/internal';
 
 export default defineComponent({
     name: 'DetailsButtonRendererV',
-    props: ['params'],
-
+    data(props) {
+        return {
+            params: props.params as any
+        };
+    },
     mounted() {
         // need to hoist events to top level cell wrapper to be keyboard accessible
         this.params.eGridCell.addEventListener('keydown', (e: KeyboardEvent) => {

--- a/packages/ramp-core/src/fixtures/grid/templates/zoom-button-renderer.vue
+++ b/packages/ramp-core/src/fixtures/grid/templates/zoom-button-renderer.vue
@@ -24,13 +24,12 @@ import { LayerInstance } from '@/api/internal';
 
 export default defineComponent({
     name: 'ZoomButtonRendererV',
-    props: ['params'],
-    data() {
+    data(props) {
         return {
+            params: props.params as any,
             getLayerByUid: get('layer/getLayerByUid')
         };
     },
-
     mounted() {
         // need to hoist events to top level cell wrapper to be keyboard accessible
         this.params.eGridCell.addEventListener('keydown', (e: KeyboardEvent) => {


### PR DESCRIPTION
**Changes in this PR**
- the `props` warning will no longer be spammed in the console when scrolling through/using the grid
- removed the warning about the component being reactive that pops up when opening the grid

**Concerns**
¯\\\_(ツ)\_/¯

**Testing this PR**
You can find a demo for this PR [here](http://ramp4-app.azureedge.net/demo/users/RyanCoulsonCA/vue3-grid-errors/host/index.html).

To test, just open the various grids and check the console. There should be no grid-related warnings.