### PR TITLE
Fix details feature count reactivity

### DIFF
--- a/packages/ramp-core/src/fixtures/details/api/details.ts
+++ b/packages/ramp-core/src/fixtures/details/api/details.ts
@@ -1,11 +1,6 @@
 import { FixtureInstance } from '@/api';
 import { IdentifyItem, IdentifyResult } from '@/geo/api';
-import {
-    DetailsConfig,
-    DetailsItemSet,
-    DetailsItemInstance,
-    DetailsStore
-} from '../store';
+import { DetailsConfig, DetailsItemSet, DetailsItemInstance, DetailsStore } from '../store';
 
 export class DetailsAPI extends FixtureInstance {
     get config(): DetailsConfig | undefined {
@@ -47,7 +42,7 @@ export class DetailsAPI extends FixtureInstance {
         const identifyResult: IdentifyResult = {
             items: [identifyItem],
             uid: uid,
-            isLoading: false
+            loadPromise: Promise.resolve()
         };
 
         // Save the provided identify result in the store.
@@ -73,9 +68,7 @@ export class DetailsAPI extends FixtureInstance {
     _parseConfig(config?: DetailsConfig) {
         if (!config) return;
 
-        const detailsItems = config.items.map(
-            (item: any) => new DetailsItemInstance(item)
-        );
+        const detailsItems = config.items.map((item: any) => new DetailsItemInstance(item));
 
         // save the items in the store
         this.$vApp.$store.set(
@@ -96,9 +89,7 @@ export class DetailsAPI extends FixtureInstance {
      */
     _validateItems() {
         Object.values(
-            this.$vApp.$store.get<DetailsItemInstance[]>(
-                DetailsStore.templates
-            )!
+            this.$vApp.$store.get<DetailsItemInstance[]>(DetailsStore.templates)!
         ).forEach(item => {
             if (item.template in this.$vApp.$options.components!) {
                 this.$vApp.$store.set(

--- a/packages/ramp-core/src/fixtures/details/layers-screen.vue
+++ b/packages/ramp-core/src/fixtures/details/layers-screen.vue
@@ -11,23 +11,24 @@
             <div class="p-5">
                 {{
                     $t('details.layers.found', {
-                        numResults: getPayloadResults(),
+                        numResults: getPayloadTotalCount,
                         numLayers: payload.length
                     })
                 }}
             </div>
             <div
                 class="px-20 py-10 text-md flex hover:bg-gray-200 cursor-pointer"
-                v-for="(item, idx) in payload"
-                :key="`${idx}-${item.items.length}`"
-                @click="openResult(idx)"
+                v-for="(item, idx) in layerResults"
+                :key="`${item ? item.uid : 'loading'}-${idx}`"
+                @click="item && openResult(idx)"
             >
                 <div v-truncate>
                     {{ layerInfo(idx) || $t('details.layers.loading') }}
                 </div>
                 <div class="flex-auto"></div>
-                <!-- Vue doesn't seem to be rerendering when item.items changes -->
-                <div class="px-5">{{ item.items.length }}</div>
+                <!-- Display the count if item exists, else display the loading spinner -->
+                <div v-if="item" class="px-5">{{ item.items.length }}</div>
+                <div v-else class="animate-spin custom-spinner h-20 w-20 px-5"></div>
             </div>
         </template>
     </panel-screen>
@@ -48,12 +49,42 @@ export default defineComponent({
     },
     data() {
         return {
+            layerResults: [] as Array<IdentifyResult | undefined>,
             payload: get(DetailsStore.payload),
             getLayerByUid: get('layer/getLayerByUid'),
             layers: get('layer/layers')
         };
     },
+    computed: {
+        getPayloadTotalCount(): any {
+            return this.layerResults
+                .map((r: IdentifyResult | undefined) => (r ? r.items.length : 0))
+                .reduce((a: number, b: number) => a + b, 0);
+        }
+    },
+    watch: {
+        payload: {
+            deep: true,
+            immediate: true,
+            handler(newPayload) {
+                // Reload items
+                this.loadPayloadItems(newPayload);
+            }
+        }
+    },
     methods: {
+        /**
+         * Load identify result items after all item's load promise has resolved
+         */
+        loadPayloadItems(newPayload: Array<IdentifyResult>): void {
+            this.layerResults = new Array(newPayload.length).fill(undefined);
+            newPayload.forEach((item: IdentifyResult, idx: number) =>
+                item.loadPromise.then(() => {
+                    this.layerResults[idx] = item;
+                })
+            );
+        },
+
         /**
          * Switches the panel screen to display the data for a given result.
          */
@@ -72,6 +103,9 @@ export default defineComponent({
             }
         },
 
+        /**
+         * Get the layer name given layer's payload index
+         */
         layerInfo(idx: number) {
             const layerInfo = this.payload[idx];
             // Check to see if there is a custom template defined for the selected layer.
@@ -91,15 +125,16 @@ export default defineComponent({
             if (!item) return;
 
             return item.getName(layerInfo.uid);
-        },
-        // later, this should probably go into computed. leaving it here until we get the reactivity issues figured out.
-        getPayloadResults(): any {
-            return this.payload
-                .map((r: IdentifyResult) => r.items.length)
-                .reduce((a: number, b: number) => a + b, 0);
         }
     }
 });
 </script>
 
-<style lang="scss"></style>
+<style lang="scss">
+.custom-spinner {
+    border: 2px solid rgba(0, 0, 0, 0.158);
+    border-top: 2px solid #3f51b5;
+    border-right: 2px solid #3f51b5;
+    border-radius: 50%;
+}
+</style>

--- a/packages/ramp-core/src/geo/api/geo-defs.ts
+++ b/packages/ramp-core/src/geo/api/geo-defs.ts
@@ -333,7 +333,7 @@ export interface IdentifyItem {
 export interface IdentifyResult {
     items: Array<IdentifyItem>;
     uid: string; // this would match to the FC. TODO might want to name the property something more specific to that, like sublayerUid? indexUid? childUid? might be ok with uid as the parentUid is different name
-    isLoading: boolean; // TODO confirm we still need this. the .done of IdentifyResultSet should provide the same information. maybe it's a binding thing (bind to bool > bind to promise?)
+    loadPromise: Promise<void>; // TODO confirm we still need this. the .done of IdentifyResultSet should provide the same information. maybe it's a binding thing (bind to bool > bind to promise?)
 }
 
 export interface IdentifyResultSet {

--- a/packages/ramp-core/src/geo/layer/esriFeature/index.ts
+++ b/packages/ramp-core/src/geo/layer/esriFeature/index.ts
@@ -26,9 +26,7 @@ class FeatureLayer extends AttribLayer {
 
     async initiate(): Promise<void> {
         markRaw(
-            (this.esriLayer = new EsriFeatureLayer(
-                this.makeEsriLayerConfig(this.origRampConfig)
-            ))
+            (this.esriLayer = new EsriFeatureLayer(this.makeEsriLayerConfig(this.origRampConfig)))
         );
         await super.initiate();
     }
@@ -39,9 +37,7 @@ class FeatureLayer extends AttribLayer {
      * @param rampLayerConfig snippet from RAMP for this layer
      * @returns configuration object for the ESRI layer representing this layer
      */
-    protected makeEsriLayerConfig(
-        rampLayerConfig: RampLayerConfig
-    ): __esri.FeatureLayerProperties {
+    protected makeEsriLayerConfig(rampLayerConfig: RampLayerConfig): __esri.FeatureLayerProperties {
         // TODO flush out
         // NOTE: it would be nice to put esri.LayerProperties as the return type, but since we are cheating with refreshInterval it wont work
         //       we can make our own interface if it needs to happen (or can extent the esri one)
@@ -54,8 +50,7 @@ class FeatureLayer extends AttribLayer {
         if (rampLayerConfig.initialFilteredQuery) {
             // TODO do we need to add something to the .filter? or is this
             //      a fixed query never goes away?
-            esriConfig.definitionExpression =
-                rampLayerConfig.initialFilteredQuery;
+            esriConfig.definitionExpression = rampLayerConfig.initialFilteredQuery;
         }
         return esriConfig;
     }
@@ -111,9 +106,7 @@ class FeatureLayer extends AttribLayer {
         const featFC = new FeatureFC(this, featIdx);
         this.fcs[featIdx] = featFC;
         featFC.serviceUrl = layerUrl;
-        this.layerTree.children.push(
-            new TreeNode(featIdx, featFC.uid, this.name)
-        ); // TODO verify name is populated at this point
+        this.layerTree.children.push(new TreeNode(featIdx, featFC.uid, this.name)); // TODO verify name is populated at this point
         featFC.name = this.name; // feature layer is flat, so the FC and layer share their name
 
         // TODO see if we need to re-synch the parent name
@@ -123,16 +116,12 @@ class FeatureLayer extends AttribLayer {
         // TODO check if we have custom renderer, add to options parameter here
         const pLD: Promise<void> = featFC.loadLayerMetadata().then(() => {
             if (!featFC.attLoader) {
-                throw new Error(
-                    'layer metadata loader did not create attribute loader'
-                );
+                throw new Error('layer metadata loader did not create attribute loader');
             }
 
             // apply any config based overrides to the data we just downloaded
-            featFC.nameField =
-                this.origRampConfig.nameField || featFC.nameField || '';
-            featFC.tooltipField =
-                this.origRampConfig.tooltipField || featFC.nameField;
+            featFC.nameField = this.origRampConfig.nameField || featFC.nameField || '';
+            featFC.tooltipField = this.origRampConfig.tooltipField || featFC.nameField;
 
             featFC.processFieldMetadata(this.origRampConfig.fieldMetadata);
             featFC.attLoader.updateFieldList(featFC.fieldList);
@@ -209,9 +198,12 @@ class FeatureLayer extends AttribLayer {
             return super.identify(options);
         }
 
+        let loadResolve: any;
         const innerResult: IdentifyResult = {
             uid: myFC.uid,
-            isLoading: true,
+            loadPromise: new Promise(resolve => {
+                loadResolve = resolve;
+            }),
             items: []
         };
 
@@ -261,7 +253,8 @@ class FeatureLayer extends AttribLayer {
                 };
             });
 
-            innerResult.isLoading = false;
+            // Resolve the load promise
+            loadResolve();
         });
 
         return result;

--- a/packages/ramp-core/src/geo/layer/esriMapImage/index.ts
+++ b/packages/ramp-core/src/geo/layer/esriMapImage/index.ts
@@ -195,12 +195,12 @@ class MapImageLayer extends AttribLayer {
             [key: number]: RampLayerMapImageLayerEntryConfig;
         } = {};
 
-        (<Array<RampLayerMapImageLayerEntryConfig>>(
-            this.origRampConfig.layerEntries
-        )).forEach((le: RampLayerMapImageLayerEntryConfig) => {
-            // TODO the || 0 is there to handle missing index. probably will never happen. add an error check?
-            subConfigs[le.index || 0] = le;
-        });
+        (<Array<RampLayerMapImageLayerEntryConfig>>this.origRampConfig.layerEntries).forEach(
+            (le: RampLayerMapImageLayerEntryConfig) => {
+                // TODO the || 0 is there to handle missing index. probably will never happen. add an error check?
+                subConfigs[le.index || 0] = le;
+            }
+        );
 
         // subfunction to return a subconfig object.
         // if it does not exist or is not defaulted, will do that first
@@ -249,10 +249,7 @@ class MapImageLayer extends AttribLayer {
         // it will generate FCs for all leafs under the sublayer
         // we also generate a tree structure of our layer that is in a format
         // that makes the client happy
-        const processSublayer = (
-            subLayer: __esri.Sublayer,
-            parentTreeNode: TreeNode
-        ): void => {
+        const processSublayer = (subLayer: __esri.Sublayer, parentTreeNode: TreeNode): void => {
             const sid: number = subLayer.id;
             const subC = subConfigs[sid];
 
@@ -270,19 +267,13 @@ class MapImageLayer extends AttribLayer {
                 // leaf sublayer. make placeholders, add leaf to the tree
                 if (!this.fcs[sid]) {
                     const miFC = new MapImageFC(this, sid);
-                    const lName =
-                        (subC ? subC.name : '') || subLayer.title || ''; // config if exists, else server, else none
+                    const lName = (subC ? subC.name : '') || subLayer.title || ''; // config if exists, else server, else none
                     miFC.name = lName;
                     this.fcs[sid] = miFC;
                     leafsToInit.push(miFC);
                 }
 
-                const treeLeaf = new TreeNode(
-                    sid,
-                    this.fcs[sid].uid,
-                    this.fcs[sid].name,
-                    true
-                );
+                const treeLeaf = new TreeNode(sid, this.fcs[sid].uid, this.fcs[sid].name, true);
                 parentTreeNode.children.push(treeLeaf);
 
                 subLayer.watch('visible', () => {
@@ -301,9 +292,7 @@ class MapImageLayer extends AttribLayer {
         };
 
         // process the child layers our config is interested in, and all their children.
-        (<Array<RampLayerMapImageLayerEntryConfig>>(
-            this.origRampConfig.layerEntries
-        )).forEach(le => {
+        (<Array<RampLayerMapImageLayerEntryConfig>>this.origRampConfig.layerEntries).forEach(le => {
             if (!le.stateOnly) {
                 // TODO add a check instead of 0 default on the index?
                 const rootSub = findSublayer(le.index || 0);
@@ -341,9 +330,7 @@ class MapImageLayer extends AttribLayer {
                 // do any things that are specific to feature or raster subtypes
                 if (mlFC.supportsFeatures) {
                     if (!mlFC.attLoader) {
-                        throw new Error(
-                            'Map Image FC - expected attLoader to exist'
-                        );
+                        throw new Error('Map Image FC - expected attLoader to exist');
                     }
                     mlFC.attLoader.updateFieldList(mlFC.fieldList);
                     return mlFC.loadFeatureCount();
@@ -362,10 +349,7 @@ class MapImageLayer extends AttribLayer {
         // any sublayers not in our tree, we need to turn off.
         this.esriLayer.allSublayers.forEach(s => {
             // find sublayers that are not groups, and dont exist in our initilazation array
-            if (
-                !s.sublayers &&
-                !leafsToInit.find((fc: MapImageFC) => fc.layerIdx === s.id)
-            ) {
+            if (!s.sublayers && !leafsToInit.find((fc: MapImageFC) => fc.layerIdx === s.id)) {
                 s.visible = false;
             }
         });
@@ -424,11 +408,11 @@ class MapImageLayer extends AttribLayer {
                 // layerIdx is a layer index
                 const layerEntries: Array<RampLayerMapImageLayerEntryConfig> =
                     this.origRampConfig.layerEntries || [];
-                const layer = (<Array<RampLayerMapImageLayerEntryConfig>>(
-                    layerEntries
-                )).filter((layer: any) => {
-                    return layer.index === layerIdx;
-                })[0];
+                const layer = (<Array<RampLayerMapImageLayerEntryConfig>>layerEntries).filter(
+                    (layer: any) => {
+                        return layer.index === layerIdx;
+                    }
+                )[0];
                 if (layer && layer.name) {
                     return layer.name;
                 } else {
@@ -474,10 +458,7 @@ class MapImageLayer extends AttribLayer {
      * @param {Boolean} value the new visibility setting
      * @param {Integer} [layerIdx] targets a layer index to set visibility for. Layer visibility is set if omitted.
      */
-    setVisibility(
-        value: boolean,
-        layerIdx: number | string | undefined = undefined
-    ): void {
+    setVisibility(value: boolean, layerIdx: number | string | undefined = undefined): void {
         const fc = this.getFC(layerIdx, true);
         if (!fc) {
             if (this.esriLayer) {
@@ -518,10 +499,7 @@ class MapImageLayer extends AttribLayer {
      * @param {Decimal} value the new opacity setting. Valid value is anything between 0 and 1, inclusive.
      * @param {Integer} [layerIdx] targets a layer index to get opacity for. Layer opacity is set if omitted.
      */
-    setOpacity(
-        value: number,
-        layerIdx: number | string | undefined = undefined
-    ): void {
+    setOpacity(value: number, layerIdx: number | string | undefined = undefined): void {
         const fc = this.getFC(layerIdx, true);
         if (!fc || !this.isDynamic) {
             if (this.esriLayer) {
@@ -577,14 +555,12 @@ class MapImageLayer extends AttribLayer {
 
         // change any sublayer ids that are server indices to sublayer uids.
         if (options.sublayerIds) {
-            options.sublayerIds = options.sublayerIds.map(
-                (id: number | string) => {
-                    if (typeof id === 'number') {
-                        return <string>this.layerTree?.findChildByIdx(id)?.uid;
-                    }
-                    return id;
+            options.sublayerIds = options.sublayerIds.map((id: number | string) => {
+                if (typeof id === 'number') {
+                    return <string>this.layerTree?.findChildByIdx(id)?.uid;
                 }
-            );
+                return id;
+            });
         }
 
         const activeFCs: Array<MapImageFC> = options.sublayerIds
@@ -632,9 +608,12 @@ class MapImageLayer extends AttribLayer {
         // loop over active FCs. call query on each. prepare a geometry
         result.done = Promise.all(
             activeFCs.map(fc => {
+                let loadResolve: any;
                 const innerResult: IdentifyResult = {
                     uid: fc.uid,
-                    isLoading: true,
+                    loadPromise: new Promise(resolve => {
+                        loadResolve = resolve;
+                    }),
                     items: []
                 };
                 result.results.push(innerResult);
@@ -669,7 +648,8 @@ class MapImageLayer extends AttribLayer {
                         };
                     });
 
-                    innerResult.isLoading = false;
+                    // Resolve the load promise
+                    loadResolve();
                 });
             })
         ).then(() => Promise.resolve()); // just to stop typescript from crying about array result of .all()


### PR DESCRIPTION
## Fixes in this PR
- [FIX] Details panel now properly displays the feature count with reactivity
- [FEAT] Feature count will show a loading spinner if the `IdentifyResult` is still loading
- [FEAT] `IdentifyResult` instances now uses a `loadPromise` instead of a `isLoading` boolean

## Further work:
- Invisible layers and symbols need to be omitted from the identify results [Added to list✔]

## Steps to test
[Demo](http://ramp4-app.azureedge.net/demo/users/sharvenp/vue3-details-fixture/host/index.html)
[Demo - WMS](http://ramp4-app.azureedge.net/demo/users/sharvenp/vue3-details-fixture/host/index-e2e.html?script=wms-layer)

1. Load demo
2. Click on the map features - the details panel should show the proper count of the features hit
3. Expand one of the results - the number of listed symbols should match the count
4. Go back and keep clicking at different points - the feature count should update each time
5. Try the same with the WMS demo