### PR TITLE
Fix identify visibility bug

### DIFF
--- a/packages/ramp-core/src/geo/layer/esriMapImage/index.ts
+++ b/packages/ramp-core/src/geo/layer/esriMapImage/index.ts
@@ -579,7 +579,7 @@ class MapImageLayer extends AttribLayer {
               });
 
         // early kickout check. all sublayers are one of: not visible; not queryable; off scale; a raster layer
-        if (activeFCs.length === 0) {
+        if (activeFCs.length === 0 || !this.getVisibility()) {
             // return empty result.
             return super.identify(options);
         }


### PR DESCRIPTION
## Fixes in this PR
- [FIX] Invisible `MapImage` layers are now omitted from the identify results

## Steps to test
[Demo](http://ramp4-app.azureedge.net/demo/users/sharvenp/vue3-details-invisible/host/index.html)
[Demo - WMS](http://ramp4-app.azureedge.net/demo/users/sharvenp/vue3-details-invisible/host/index-e2e.html?script=wms-layer)

1. Load Demo
2. Toggle the visibility of layers and click on the map - invisible layers should not appear in the results panel (especially `MapImage` layers)
3.  Toggle the symbology visibility of `MapImage` layers and check if the invisible symbols are not included in the identify results
4. Try step 2. with WMS layers