### PR TITLE
fix tooltips in grid subcomponents

### DIFF
--- a/packages/ramp-core/src/fixtures/grid/templates/custom-header.vue
+++ b/packages/ramp-core/src/fixtures/grid/templates/custom-header.vue
@@ -1,18 +1,13 @@
 <template>
     <div class="ag-custom-header flex flex-1 items-center h-full w-full">
         <div v-if="sortable" class="flex flex-1 items-center min-w-0">
-            <!-- <button
+            <button
                 @click="onSortRequested('asc', $event)"
                 :content="$t(`grid.header.sort.${sort}`)"
                 v-tippy="{ placement: 'top', hideOnClick: false }"
                 class="customHeaderLabel hover:bg-gray-300 font-bold p-8 max-w-full"
                 role="columnheader"
                 truncate-trigger
-            > -->
-            <button
-                @click="onSortRequested('asc', $event)"
-                class="customHeaderLabel hover:bg-gray-300 font-bold p-8 max-w-full"
-                role="columnheader"
             >
                 <!-- <div v-truncate="{ externalTrigger: true }"> -->
                 <div>
@@ -44,14 +39,9 @@
                     </svg>
                 </div>
             </span>
-            <!-- <button
+            <button
                 :content="$t(`grid.header.reorder.left`)"
                 v-tippy="{ placement: 'top' }"
-                @click="moveLeft()"
-                class="opacity-60 hover:opacity-90 disabled:opacity-30 disabled:cursor-default"
-                :disabled="!canMoveLeft"
-            > -->
-            <button
                 @click="moveLeft()"
                 class="opacity-60 hover:opacity-90 disabled:opacity-30 disabled:cursor-default"
                 :disabled="!canMoveLeft"
@@ -64,14 +54,9 @@
                     </svg>
                 </div>
             </button>
-            <!-- <button
+            <button
                 :content="$t(`grid.header.reorder.right`)"
                 v-tippy="{ placement: 'top' }"
-                @click="moveRight()"
-                class="opacity-60 hover:opacity-90 disabled:opacity-30 disabled:cursor-default"
-                :disabled="!canMoveRight"
-            > -->
-            <button
                 @click="moveRight()"
                 class="opacity-60 hover:opacity-90 disabled:opacity-30 disabled:cursor-default"
                 :disabled="!canMoveRight"
@@ -90,9 +75,13 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
+import { directive as tippyDirective } from 'vue-tippy';
 
 export default defineComponent({
     name: 'GridCustomHeaderV',
+    directives: {
+        tippy: tippyDirective
+    },
     data(props) {
         return {
             params: props.params as any,

--- a/packages/ramp-core/src/fixtures/grid/templates/details-button-renderer.vue
+++ b/packages/ramp-core/src/fixtures/grid/templates/details-button-renderer.vue
@@ -2,6 +2,7 @@
     <button
         class="w-38 h-48"
         :content="$t('grid.cells.details')"
+        v-tippy="{ placement: 'top' }"
         @click="openDetails"
         tabindex="-1"
     >
@@ -25,9 +26,13 @@ import { defineComponent } from 'vue';
 
 import deepmerge from 'deepmerge';
 import { GlobalEvents } from '@/api/internal';
+import { directive as tippyDirective } from 'vue-tippy';
 
 export default defineComponent({
     name: 'DetailsButtonRendererV',
+    directives: {
+        tippy: tippyDirective
+    },
     data(props) {
         return {
             params: props.params as any

--- a/packages/ramp-core/src/fixtures/grid/templates/zoom-button-renderer.vue
+++ b/packages/ramp-core/src/fixtures/grid/templates/zoom-button-renderer.vue
@@ -1,5 +1,11 @@
 <template>
-    <button class="w-38 h-48" :content="$t('grid.cells.zoom')" @click="zoomToFeature" tabindex="-1">
+    <button
+        class="w-38 h-48"
+        :content="$t('grid.cells.zoom')"
+        v-tippy="{ placement: 'top' }"
+        @click="zoomToFeature"
+        tabindex="-1"
+    >
         <svg
             class="m-auto"
             xmlns="http://www.w3.org/2000/svg"
@@ -21,9 +27,13 @@ import { defineComponent } from 'vue';
 import { Vue } from 'vue-property-decorator';
 import { get } from '@/store/pathify-helper';
 import { LayerInstance } from '@/api/internal';
+import { directive as tippyDirective } from 'vue-tippy';
 
 export default defineComponent({
     name: 'ZoomButtonRendererV',
+    directives: {
+        tippy: tippyDirective
+    },
     data(props) {
         return {
             params: props.params as any,


### PR DESCRIPTION
**Changes in this PR**
- tippy tooltips will now appear when hovering over grid sub-components

**Concerns**
None

**Testing this PR**
You can find a demo of this PR [here](http://ramp4-app.azureedge.net/demo/users/RyanCoulsonCA/vue3-grid-tippy-fix/host/index.html).

To test, open a grid and hover over sub-components (the grid/zoom buttons, shift column left/right, ascend/descend, etc.) and ensure that the tooltip appears on hover.