### PR TITLE
fix grid filter styling issues

### DIFF
--- a/packages/ramp-core/src/fixtures/grid/templates/custom-date-filter.vue
+++ b/packages/ramp-core/src/fixtures/grid/templates/custom-date-filter.vue
@@ -1,23 +1,20 @@
 <template>
-    <div class="h-full flex items-center justify-center">
-        <div class="inline float-left text-xs w-1/2">
-            <input
-                class="rv-input"
-                type="date"
-                placeholder="date min"
-                v-model="minVal"
-                @change="minValChanged()"
-            />
-        </div>
-        <div class="inline float-left w-1/2">
-            <input
-                class="rv-input"
-                type="date"
-                placeholder="date max"
-                v-model="maxVal"
-                @change="maxValChanged()"
-            />
-        </div>
+    <div class="h-full flex items-center justify-center w-full">
+        <input
+            class="m-0 py-1 w-1/2 rv-input bg-transparent text-black-75 h-24 pb-8 border-0 border-b-2 pl-3"
+            type="date"
+            placeholder="date min"
+            v-model="minVal"
+            @change="minValChanged()"
+        />
+
+        <input
+            class="m-0 py-1 w-1/2 rv-input bg-transparent text-black-75 h-24 pb-8 border-0 border-b-2 pl-3"
+            type="date"
+            placeholder="date max"
+            v-model="maxVal"
+            @change="maxValChanged()"
+        />
     </div>
 </template>
 

--- a/packages/ramp-core/src/fixtures/grid/templates/custom-number-filter.vue
+++ b/packages/ramp-core/src/fixtures/grid/templates/custom-number-filter.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="h-full flex items-center justify-center">
         <input
-            class="rv-min rv-input"
+            class="rv-min rv-input bg-transparent text-black-75 h-24 pb-8 border-0 border-b-2"
             style="width: 45%;"
             type="text"
             v-model="minVal"
@@ -9,7 +9,7 @@
             placeholder="min"
         />
         <input
-            class="rv-max rv-input"
+            class="rv-max rv-input bg-transparent text-black-75 h-24 pb-8 border-0 border-b-2"
             style="width: 45%;"
             type="text"
             v-model="maxVal"

--- a/packages/ramp-core/src/fixtures/grid/templates/custom-selector-filter.vue
+++ b/packages/ramp-core/src/fixtures/grid/templates/custom-selector-filter.vue
@@ -1,6 +1,10 @@
 <template>
     <div class="h-full flex items-center justify-center">
-        <select class="rv-input w-full" v-model="selectedOption" @change="selectionChanged()">
+        <select
+            class="rv-input w-full bg-transparent text-black-75 h-24 pb-8 border-0 border-b-2"
+            v-model="selectedOption"
+            @change="selectionChanged()"
+        >
             <option v-for="option in options" :value="option" :key="option">
                 {{ option }}
             </option>

--- a/packages/ramp-core/src/fixtures/grid/templates/custom-text-filter.vue
+++ b/packages/ramp-core/src/fixtures/grid/templates/custom-text-filter.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="h-full flex items-center justify-center">
         <input
-            class="rv-input w-full"
+            class="rv-input w-full bg-transparent text-black-75 h-24 pb-8 border-0 border-b-2"
             type="text"
             @keyup="valueChanged()"
             v-model="filterValue"
@@ -76,7 +76,7 @@ export default interface GridCustomTextFilter {
 }
 </script>
 
-<style lang="scss" scoped>
+<style lang="scss">
 .ag-floating-filter-full-body input,
 .ag-floating-filter-full-body select,
 .rv-global-search {


### PR DESCRIPTION
**Changes in this PR**
- The column filter input boxes now show the correct style.

**Concerns**
I'm not sure if this is the best way to go about this. I tried playing around with it a bunch, but it doesn't seem like the `@apply` is working for this.

**Testing this PR**
You can find a demo for this PR [here](http://ramp4-app.azureedge.net/demo/users/RyanCoulsonCA/vue3-grid-style-fix/host/index.html).

To test, open the grid and make sure that the input boxes are correctly styled for each filter type (number, date, text, etc.)