### PR TITLE
Refactor beforeDestroy calls to use beforeUnmounted

### DIFF
--- a/packages/ramp-core/src/components/controls/dropdown-menu.vue
+++ b/packages/ramp-core/src/components/controls/dropdown-menu.vue
@@ -25,29 +25,27 @@
 </template>
 
 <script lang="ts">
-import { Vue, Prop, Watch } from 'vue-property-decorator';
-// @ts-ignore
+import { defineComponent } from 'vue';
 import { createPopper, Placement } from '@popperjs/core';
 
-export default class DropdownMenuV extends Vue {
-    @Prop({ default: 'bottom' }) position!: Placement;
-    @Prop() tooltip?: string;
-    @Prop({ default: 'bottom' }) tooltipPlacement?: string;
-    @Prop({ default: 'ramp4' }) tooltipTheme?: string;
-    @Prop({ default: 'scale' }) tooltipAnimation?: string;
-
-    open: boolean = false;
-    popper: any;
-
-    closeDropdown() {
-        this.open = false;
-    }
-
-    @Watch('open')
-    updatePopperPositioning() {
-        this.popper.update();
-    }
-
+export default defineComponent({
+    name: 'DropdownMenuV',
+    props: {
+        position: {
+            type: String,
+            default: 'bottom'
+        },
+        tooltip: { type: String },
+        tooltipPlacement: { type: String, default: 'bottom' },
+        tooltipTheme: { type: String, default: 'ramp4' },
+        tooltipAnimation: { type: String, default: 'scale' }
+    },
+    data() {
+        return {
+            open: false,
+            popper: null as any
+        };
+    },
     mounted() {
         window.addEventListener(
             'click',
@@ -65,7 +63,7 @@ export default class DropdownMenuV extends Vue {
                 this.$refs['dropdown-trigger'] as Element,
                 this.$refs['dropdown'] as HTMLElement,
                 {
-                    placement: this.position || 'bottom',
+                    placement: (this.position || 'bottom') as Placement,
                     modifiers: [
                         {
                             name: 'offset',
@@ -77,9 +75,8 @@ export default class DropdownMenuV extends Vue {
                 }
             );
         });
-    }
-
-    beforeDestroy() {
+    },
+    beforeUnmount() {
         window.removeEventListener(
             'click',
             event => {
@@ -89,8 +86,18 @@ export default class DropdownMenuV extends Vue {
             },
             { capture: true }
         );
+    },
+    watch: {
+        open() {
+            this.popper.update();
+        }
+    },
+    methods: {
+        closeDropdown() {
+            this.open = false;
+        }
     }
-}
+});
 </script>
 
 <style lang="scss">

--- a/packages/ramp-core/src/fixtures/settings/screen.vue
+++ b/packages/ramp-core/src/fixtures/settings/screen.vue
@@ -94,33 +94,33 @@
 </template>
 
 <script lang="ts">
-import { Vue, Options, Prop } from 'vue-property-decorator';
-
+import { defineComponent, PropType } from 'vue';
 import { PanelInstance } from '@/api';
-
 import SettingsComponentV from './component.vue';
 import { GlobalEvents, LayerInstance } from '@/api/internal';
 import { LegendEntry } from '../legend/store/legend-defs';
 import { LayerType } from '@/geo/api';
 
-@Options({
+export default defineComponent({
+    name: 'SettingsScreenV',
+    props: {
+        panel: { type: Object as PropType<PanelInstance>, required: true },
+        layer: { type: Object as PropType<LayerInstance>, required: true },
+        uid: { type: String, required: true },
+        legendItem: { type: Object as PropType<LegendEntry>, required: true }
+    },
     components: {
         'settings-component': SettingsComponentV
-    }
-})
-export default class SettingsScreenV extends Vue {
-    @Prop() panel!: PanelInstance;
-    @Prop() layer!: LayerInstance;
-    @Prop() uid!: string;
-    @Prop() legendItem!: LegendEntry;
-
-    // Models.
-    layerName: string = '';
-    visibilityModel: boolean = this.layer.getVisibility(this.uid);
-    opacityModel: number = this.layer.getOpacity(this.uid) * 100;
-    snapshotToggle: boolean = false;
-    handlers: Array<string> = [];
-
+    },
+    data() {
+        return {
+            layerName: '',
+            visibilityModel: this.layer.getVisibility(this.uid),
+            opacityModel: this.layer.getOpacity(this.uid) * 100,
+            snapshotToggle: false,
+            handlers: [] as Array<string>
+        };
+    },
     mounted() {
         // Listen for a layer load event. Some of these values may change when the layer fully loads.
         this.layer.isLayerLoaded().then(() => {
@@ -149,31 +149,31 @@ export default class SettingsScreenV extends Vue {
                 }
             })
         );
-    }
-
-    beforeDestroy() {
+    },
+    beforeUnmount() {
         // Remove all event handlers for this component
         this.handlers.forEach(handler => this.$iApi.event.off(handler));
-    }
+    },
+    methods: {
+        // Update the layer visibility.
+        updateVisibility(val: any) {
+            this.legendItem.toggleVisibility(val.value);
+            this.visibilityModel = val.value;
+        },
 
-    // Update the layer visibility.
-    updateVisibility(val: any) {
-        this.legendItem.toggleVisibility(val.value);
-        this.visibilityModel = val.value;
-    }
+        // Update the layer opacity.
+        updateOpacity(val: number) {
+            this.opacityModel = val;
+            this.layer.setOpacity(this.opacityModel / 100, this.uid);
+        },
 
-    // Update the layer opacity.
-    updateOpacity(val: number) {
-        this.opacityModel = val;
-        this.layer.setOpacity(this.opacityModel / 100, this.uid);
+        // Toggle snapshot mode for the layer.
+        toggleSnapshot() {
+            this.snapshotToggle = !this.snapshotToggle;
+            // TODO: make necessary changes to layer
+        }
     }
-
-    // Toggle snapshot mode for the layer.
-    toggleSnapshot() {
-        this.snapshotToggle = !this.snapshotToggle;
-        // TODO: make necessary changes to layer
-    }
-}
+});
 </script>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
## Fixes in this PR
- [FIX] Updated all uses of `beforeDestroy` to `beforeUnmount`
- [FIX] Refactored `DropdownMenuV` and `SettingsScreenV` components to use `defineComponent`


## Steps to test
[Demo](http://ramp4-app.azureedge.net/demo/users/sharvenp/vue3-before-destroy/host/index.html)

There is no real way to test the `beforeUnmount` calls since they mostly do clean-up. Hence the functionality of these components can be tested instead:

1. Load Demo
 2. The dropdown menus and settings panel should work properly 
     - No errors/warnings in the console apart from the usual `markRaw` ones
 3. Close an re-open them a couple of times and check if they still work 