### PR TITLE
Add wizard validation and multi-select input support for wms/dynamic layers

### DIFF
--- a/packages/ramp-core/src/fixtures/appbar/index.ts
+++ b/packages/ramp-core/src/fixtures/appbar/index.ts
@@ -1,4 +1,3 @@
-import { createApp } from 'vue';
 import AppbarV from './appbar.vue';
 import { AppbarAPI } from './api/appbar';
 import { appbar, AppbarFixtureConfig } from './store';

--- a/packages/ramp-core/src/fixtures/help/screen.vue
+++ b/packages/ramp-core/src/fixtures/help/screen.vue
@@ -52,10 +52,7 @@ export default class HelpScreenV extends Vue {
             (newLocale: any, oldLocale: any) => {
                 if (newLocale === oldLocale) return;
                 // path to where HELP is hosted is different if RAMP is built as prod library
-                const base =
-                    process.env.VUE_APP_BUILD_TARGET === 'lib'
-                        ? '../dist/'
-                        : '/';
+                const base = process.env.VUE_APP_BUILD_TARGET === 'lib' ? '../dist/' : '/';
                 const folder = this.folderName || 'default';
                 const renderer = new marked.Renderer();
                 // make it easier to use images in markdown by prepending path to href if href is not an external source
@@ -74,10 +71,7 @@ export default class HelpScreenV extends Vue {
                     const reg = /^#\s(.*)\n{2}(?:.+|\n(?!\n{2,}))*/gm;
                     // remove new line character ASCII (13) so that above regex is compatible with all
                     // operating systems (markdown file varies by OS new line preference)
-                    let helpMd = r.data.replace(
-                        new RegExp(String.fromCharCode(13), 'g'),
-                        ''
-                    );
+                    let helpMd = r.data.replace(new RegExp(String.fromCharCode(13), 'g'), '');
                     this.helpSections = [];
                     let section;
                     while ((section = reg.exec(helpMd))) {

--- a/packages/ramp-core/src/fixtures/wizard/form-input.vue
+++ b/packages/ramp-core/src/fixtures/wizard/form-input.vue
@@ -43,8 +43,16 @@
                     type="url"
                     name="url"
                     :value="modelValue"
-                    @input="$emit('link', $event.target.value)"
+                    @change="
+                        event => {
+                            validUrl(event.target.value);
+                            $emit('link', event.target.value, !urlError);
+                        }
+                    "
                 />
+            </div>
+            <div v-if="urlError" class="text-red-900 text-xs">
+                {{ modelValue ? validationMessages.url : validationMessages.required }}
             </div>
         </div>
         <div v-else-if="type === 'select'">
@@ -55,7 +63,7 @@
                     v-bind:class="size && 'configure-select'"
                     :size="size ? size : null"
                     :value="modelValue"
-                    @input="$emit('update:modelValue', $event.target.value)"
+                    @input="$emit('select', $event.target.value)"
                 >
                     <option
                         class="p-6"
@@ -66,6 +74,9 @@
                         {{ option.label }}
                     </option>
                 </select>
+            </div>
+            <div v-if="validation && formatError" class="text-red-900 text-xs">
+                {{ validationMessages.required }}
             </div>
         </div>
         <div v-else>
@@ -98,8 +109,8 @@ interface SelectionOption {
 export default defineComponent({
     name: 'WizardInputV',
     props: {
-        formulateFile: {
-            type: [Object, Boolean],
+        formatError: {
+            type: Boolean,
             default: false
         },
         help: {
@@ -126,6 +137,10 @@ export default defineComponent({
             type: [Number, Boolean],
             default: false
         },
+        multiple: {
+            type: Boolean,
+            default: false
+        },
         type: {
             type: String,
             default: 'text'
@@ -134,7 +149,34 @@ export default defineComponent({
             type: [String, Boolean],
             default: false
         },
-        validationMessages: Object as PropType<ValidationMsgs>
+        validation: {
+            type: Boolean,
+            default: false
+        },
+        validationMessages: {
+            type: Object as PropType<ValidationMsgs>
+        }
+    },
+
+    data() {
+        return {
+            urlError: false
+        };
+    },
+
+    methods: {
+        validUrl(url: string) {
+            let newUrl;
+            try {
+                newUrl = new URL(url);
+            } catch (_) {
+                this.urlError = true;
+                return false;
+            }
+
+            const valid = newUrl.protocol === 'http:' || newUrl.protocol === 'https:';
+            valid ? (this.urlError = false) : (this.urlError = true);
+        }
     }
 });
 </script>

--- a/packages/ramp-core/src/fixtures/wizard/lang/lang.csv
+++ b/packages/ramp-core/src/fixtures/wizard/lang/lang.csv
@@ -29,6 +29,7 @@ wizard.configure.nameField.label,Primary Field,1,Champ clé,1
 wizard.configure.tooltipField.label,Tooltip Field,1,Champ infobulle,1
 wizard.configure.latField.label,Latitude Field,1,Champ latitude,1
 wizard.configure.longField.label,Longitude Field,1,Champ longitude,1
+wizard.configure.layerEntries.error.required,LayerEntries is required,1,LayerEntries sont obligatoires,0
 wizard.configure.layerEntries.label,Layers,1,Couches,1
 wizard.configure.layerEntries.help,Hold Ctrl to select multiple layers,1,Maintenez la touche Ctrl enfoncée pour sélectionner de multiples couches,0
 wizard.step.cancel,Cancel,1,Annuler,1


### PR DESCRIPTION
[Demo](http://ramp4-app.azureedge.net/demo/users/yileifeng/vue3-wizard-validation/host/index.html)

**Changes**: 
- validation checking for URL, service type selection (not completely working yet - see note), multi-selection, empty layer names
- display error messages for invalid URL input or empty input that is required
- added support for multi-select input for `layerEntries`
- map image and wms services is now able to be added through wizard

**Testing**:
Try adding dynamic and wms layers through wizard. Also make sure the error checking works (aside from some incorrect format types) and displays correctly. 

*Note*: Currently trying to fix the `errorCaptured` lifecycle hook that is needed for detecting an error when selecting certain incorrect format type (e.g. importing a wms layer and selecting feature layer as the type causes the wizard to be stuck in the configure step). Might include this in the next PR unless I find a quick fix. There is also apparently some Vue warnings for incompatible prop type checks for LayerEntries that will be fixed.

Also, let me know if there is an use case that can trigger an upload error as I did not add error checking for that but that should be easy to add if needed. 
