### PR TITLE
fix settings opacity, spinner icon

### DIFF
--- a/packages/ramp-core/src/fixtures/details/layers-screen.vue
+++ b/packages/ramp-core/src/fixtures/details/layers-screen.vue
@@ -28,7 +28,7 @@
                 <div class="flex-auto"></div>
                 <!-- Display the count if item exists, else display the loading spinner -->
                 <div v-if="item" class="px-5">{{ item.items.length }}</div>
-                <div v-else class="animate-spin custom-spinner h-20 w-20 px-5"></div>
+                <div v-else class="animate-spin spinner h-20 w-20 px-5"></div>
             </div>
         </template>
     </panel-screen>
@@ -130,11 +130,4 @@ export default defineComponent({
 });
 </script>
 
-<style lang="scss">
-.custom-spinner {
-    border: 2px solid rgba(0, 0, 0, 0.158);
-    border-top: 2px solid #3f51b5;
-    border-right: 2px solid #3f51b5;
-    border-radius: 50%;
-}
-</style>
+<style lang="scss"></style>

--- a/packages/ramp-core/src/fixtures/legend/components/entry.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/entry.vue
@@ -272,10 +272,4 @@ export default defineComponent({
     @apply text-gray-400;
     cursor: default;
 }
-.spinner {
-    border: 2px solid rgba(0, 0, 0, 0.158);
-    border-top: 2px solid #3f51b5;
-    border-right: 2px solid #3f51b5;
-    border-radius: 50%;
-}
 </style>

--- a/packages/ramp-core/src/fixtures/settings/templates/slider-control.vue
+++ b/packages/ramp-core/src/fixtures/settings/templates/slider-control.vue
@@ -8,7 +8,7 @@
             <vue-slider
                 class="mr-16"
                 @change="config.onChange"
-                :value="config.value"
+                v-model="value"
                 :width="250"
                 :min="0"
                 :max="100"
@@ -19,20 +19,24 @@
 </template>
 
 <script lang="ts">
-import { Vue, Options, Prop } from 'vue-property-decorator';
-import { Get, Sync, Call } from 'vuex-pathify';
+import { defineComponent } from 'vue';
 
 import VueSlider from 'vue-slider-component';
 import 'vue-slider-component/theme/default.css';
 
-@Options({
-    components: { VueSlider }
-})
-export default class SliderControl extends Vue {
-    @Prop() config!: any;
-    @Prop() name!: string;
-    @Prop() icon!: string;
-}
+export default defineComponent({
+    components: { VueSlider },
+    props: {
+        name: String,
+        icon: String,
+        config: Object
+    },
+    data() {
+        return {
+            value: this.config?.value
+        };
+    }
+});
 </script>
 
 <style lang="scss" scoped>

--- a/packages/ramp-core/src/fixtures/settings/templates/toggle-switch-control.vue
+++ b/packages/ramp-core/src/fixtures/settings/templates/toggle-switch-control.vue
@@ -30,32 +30,17 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue';
+import { defineComponent, reactive } from 'vue';
 import { Vue, Prop } from 'vue-property-decorator';
 
-export default class ToggleSwitchControl extends Vue {
-    @Prop() config: any;
-    @Prop() name!: string;
-    @Prop() icon!: string;
-}
-
-// export default defineComponent({
-//     name: 'ToggleSwitchControl',
-//     components: {
-//         'toggle-button': Toggle
-//     },
-//     props: {
-//         config: Object,
-//         name: String,
-//         icon: String
-//     },
-
-//     data() {
-//         return {
-//             value: this.config?.value
-//         };
-//     }
-// });
+export default defineComponent({
+    name: 'ToggleSwitchControl',
+    props: {
+        config: Object,
+        name: String,
+        icon: String
+    }
+});
 </script>
 
 <style lang="scss" scoped>

--- a/packages/ramp-core/src/styles/main.css
+++ b/packages/ramp-core/src/styles/main.css
@@ -90,3 +90,10 @@
 .tippy-box[data-theme~='ramp4'] svg {
     display: inline;
 }
+
+.spinner {
+    border: 2px solid rgba(0, 0, 0, 0.158);
+    border-top: 2px solid #3f51b5;
+    border-right: 2px solid #3f51b5;
+    border-radius: 50%;
+}


### PR DESCRIPTION
**Changes in this PR**
- fixed the opacity bar in the settings fixture. It should now be properly synced with the layer opacity.
- fixed the visibility toggle in the settings fixture. It should be synced with the layer visibility.
- fixed the spinner icon not appearing in the builds

**Concerns**
None

**Testing this PR**
You can find a demo for this PR [here](http://ramp4-app.azureedge.net/demo/users/RyanCoulsonCA/vue3-fix-settings-opacity/host/index.html).

To test, open the settings fixture for a layer and make sure that the bar is set to the same value as the text beside it. 

Click on different features on the map and make sure that the spinner is appearing properly.