### PR TITLE
Fix Gazebo fixture errors

### DIFF
--- a/packages/ramp-core/public/starter-scripts/panel-party.js
+++ b/packages/ramp-core/public/starter-scripts/panel-party.js
@@ -863,12 +863,12 @@ rInstance.$element.component('Water-Quantity-Template', {
 
 // TODO: fix console errors
 rInstance.fixture.add('snowman');
-// rInstance.fixture.add('gazebo').then(() => {
-//     rInstance.panel
-//         .get('p2')
-//         .open({ screen: 'p-2-screen-2' })
-//         .pin();
-// });
+rInstance.fixture.add('gazebo').then(() => {
+    rInstance.panel
+        .get('p2')
+        .open({ screen: 'p-2-screen-2' })
+        .pin();
+});
 // rInstance.fixture.add('diligord', window.hostFixtures.diligord).then(() => {
 //     rInstance.panel.open('diligord-p1');
 // });

--- a/packages/ramp-core/src/fixtures/gazebo/index.ts
+++ b/packages/ramp-core/src/fixtures/gazebo/index.ts
@@ -5,11 +5,9 @@ import GazeboAppbarButtonV from './appbar-button.vue';
 import GazeboP1Screen1V from './p1-screen-1.vue';
 import GazeboP1Screen2V from './p1-screen-2.vue';
 
-// import GazeboP2Screen1V from './p2-screen-1.vue';
-// import GazeboP2Screen2V from './p2-screen-2.vue';
+import GazeboP2Screen1V from './p2-screen-1.vue';
+import GazeboP2Screen2V from './p2-screen-2.vue';
 import GazeboP2Screen3V from './p2-screen-3.vue';
-
-import { AsyncComponentEh } from '@/store/modules/panel';
 
 import messages from './lang/lang.csv';
 
@@ -23,45 +21,78 @@ class GazeboFixture extends FixtureInstance {
 
         this.$iApi.component('gazebo-appbar-button', GazeboAppbarButtonV);
 
+        /**
+         * -- Vue3 Migration --
+         * All screen loading methods have been replaced with direct component loading.
+         * That is, each screen component is directly loaded by importing it above
+         *
+         * // TODO: Migrate different loading techniques from Vue2 to Vue3. Refer to the TODOs below for examples
+         */
+
         this.$iApi.panel.register(
             {
                 // panel-1 has examples of how not to bind things and interact with stuff; bad panel ❌
                 // it generally avoids using API and goes straight to the store; fixtures/panels/screens should not do that;
-                p1: {
+                id: 'p1',
+                config: {
                     screens: {
                         'p-1-screen-1': GazeboP1Screen1V,
                         'p-1-screen-2': GazeboP1Screen2V
+                    },
+                    style: {
+                        'flex-grow': '1',
+                        'max-width': '500px'
                     }
-                },
+                }
+            },
+            { i18n: { messages } }
+        );
+
+        this.$iApi.panel.register(
+            {
                 // panel-2 has examples of how properly bind things and interact with stuff; good panel ✔
                 // use API functions; underlying store structure might change and all the code accessing the store directly will break
-                p2: {
+                id: 'p2',
+                config: {
                     screens: {
-                        // manually lazy-loading a screen component
+                        /**
+                         * // TODO: This should work:
+                         * manually lazy-loading a screen component
+                         */
                         // 'p-2-screen-1': () => import(/* webpackChunkName: "p-2-screen-1" */ `./p2-screen-1.vue`),
 
-                        // for the demo purposes, delay resolution of a component by 2 seconds
-                        'p-2-screen-1': () => {
-                            return new Promise<AsyncComponentEh>(resolve =>
-                                setTimeout(
-                                    () =>
-                                        import(
-                                            /* webpackChunkName: "p-2-screen-1" */ `./p2-screen-1.vue`
-                                        ).then(data => {
-                                            resolve(data);
-                                        }),
-                                    2000
-                                )
-                            );
-                        },
+                        /**
+                         * // TODO: This should work:
+                         * for the demo purposes, delay resolution of a component by 2 seconds
+                         */
+                        // 'p-2-screen-1': () => {
+                        //     return new Promise<AsyncComponentEh>(resolve =>
+                        //         setTimeout(
+                        //             () =>
+                        //                 import(
+                        //                     /* webpackChunkName: "p-2-screen-1" */ `./p2-screen-1.vue`
+                        //                 ).then(data => {
+                        //                     resolve(data);
+                        //                 }),
+                        //             2000
+                        //         )
+                        //     );
+                        // },
 
-                        // letting the core to lazy-load a screen component; need to provide a path relative to the fixtures home folder
-                        'p-2-screen-2': 'gazebo/p2-screen-2.vue',
+                        /**
+                         * // TODO: This should work:
+                         * letting the core to lazy-load a screen component; need to provide a path relative to the fixtures home folder
+                         */
+                        // 'p-2-screen-2': 'gazebo/p2-screen-2.vue',
 
-                        // importing directly; no lazy-loading
+                        'p-2-screen-1': GazeboP2Screen1V,
+                        'p-2-screen-2': GazeboP2Screen2V,
                         'p-2-screen-3': GazeboP2Screen3V
 
-                        // returning a `VueConstructor` in a promise also works
+                        /**
+                         * // TODO: This should work:
+                         * returning a `VueConstructor` in a promise
+                         */
                         // 'p-2-screen-3': () => {
                         //     return new Promise<AsyncComponentEh>(resolve => resolve(GazeboP2Screen3V));
                         // }

--- a/packages/ramp-core/src/fixtures/gazebo/p1-screen-1.vue
+++ b/packages/ramp-core/src/fixtures/gazebo/p1-screen-1.vue
@@ -15,7 +15,7 @@
                 <pin
                     :active="pinned && pinned.id === 'p1'"
                     @click="pinPanel"
-                    v-if="$iApi.screenSize !== 'xs'"
+                    v-if="checkScreenSize"
                 ></pin>
             </div>
         </template>
@@ -37,33 +37,34 @@
 </template>
 
 <script lang="ts">
-import { Vue } from 'vue-property-decorator';
-import { Sync } from 'vuex-pathify';
-
-import { PanelConfigRoute } from '@/store/modules/panel';
+import { defineComponent } from 'vue';
+import { sync } from '@/store/pathify-helper';
 import { PanelInstance } from '../../api';
 
-export default class GazeboP1Screen1V extends Vue {
-    // ❌ this is a horrible way, don't do that! this is directly tapping into the store and two-way binds `route` property fro a specific panel
-    // this will work, but all possible interactions should go through the API, because the store implementation might change and this will break
-    // 👇
-    @Sync('panel/items@p1.route') route!: PanelConfigRoute;
-
-    // ❌ also don't do this for the reasons above 👇
-    @Sync('panel/pinned') pinned!: PanelInstance | null;
-
-    url: string =
-        'https://i2.wp.com/freepngimages.com/wp-content/uploads/2017/08/wooden-garden-gazebo.png?w=860';
-
-    pinPanel(): void {
-        // this is fine, but the name of the panel is hardcoded there, so you wouldn't need to update it if it ever changes
-        const panel = this.$store.get<PanelInstance>(`panel/items@p1`)!;
-        this.pinned =
-            this.pinned === null || (this.pinned && this.pinned.id) !== 'p1'
-                ? panel
-                : null;
+export default defineComponent({
+    name: 'GazeboP1Screen1V',
+    data() {
+        return {
+            route: sync('panel/items@p1.route'),
+            pinned: sync('panel/pinned'),
+            url:
+                'https://i2.wp.com/freepngimages.com/wp-content/uploads/2017/08/wooden-garden-gazebo.png?w=860'
+        };
+    },
+    computed: {
+        checkScreenSize(): boolean {
+            return this.$iApi.screenSize !== 'xs';
+        }
+    },
+    methods: {
+        pinPanel(): void {
+            // this is fine, but the name of the panel is hardcoded there, so you wouldn't need to update it if it ever changes
+            const panel = this.$store.get<PanelInstance>(`panel/items@p1`)!;
+            this.pinned =
+                this.pinned === null || (this.pinned && this.pinned.id) !== 'p1' ? panel : null;
+        }
     }
-}
+});
 </script>
 
 <style lang="scss" scoped></style>

--- a/packages/ramp-core/src/fixtures/gazebo/p1-screen-2.vue
+++ b/packages/ramp-core/src/fixtures/gazebo/p1-screen-2.vue
@@ -6,11 +6,7 @@
 
         <template #controls>
             <!-- this is fine, but the name of the panel is hardcoded there, so you wouldn't need to update it if it ever changes -->
-            <pin
-                :active="pinned === 'p1'"
-                @click="pinPanel"
-                v-if="$iApi.screenSize !== 'xs'"
-            ></pin>
+            <pin :active="pinned() === 'p1'" @click="pinPanel" v-if="checkScreenSize"></pin>
         </template>
 
         <template #content>
@@ -30,33 +26,38 @@
 </template>
 
 <script lang="ts">
-import { Vue } from 'vue-property-decorator';
-import { PanelInstance } from '../../api';
+import { defineComponent } from 'vue';
+import { get } from '@/store/pathify-helper';
 
-export default class GazeboP1Scree2V extends Vue {
-    url: string =
-        'https://i2.wp.com/freepngimages.com/wp-content/uploads/2016/02/garden-shed-transparent-image-2.png?w=693';
-
-    // ❌ this is bad because it's tappnig directly into the store circumventing the API
-    // this will work, but if the store changes strcture, it might break 👇
-    goToScreen(screen: string): void {
-        this.$store.set('panel/items@p1.route', { screen });
+export default defineComponent({
+    name: 'GazeboP1Scree2V',
+    data() {
+        return {
+            url:
+                'https://i2.wp.com/freepngimages.com/wp-content/uploads/2016/02/garden-shed-transparent-image-2.png?w=693'
+        };
+    },
+    computed: {
+        checkScreenSize(): boolean {
+            return this.$iApi.screenSize !== 'xs';
+        }
+    },
+    methods: {
+        pinPanel(): void {
+            // ❌ this is bad because it's tappnig directly into the store circumventing the API
+            // this will work, but if the store changes structure, it might break 👇
+            const panel = get(`panel/items@p1`) as any;
+            this.$iApi.$vApp.$store.set('panel/pinned', this.pinned() !== 'p1' ? panel : null);
+        },
+        goToScreen(screen: string): void {
+            this.$iApi.$vApp.$store.set('panel/items@p1.route', { screen });
+        },
+        pinned(): string | null {
+            const panel = get('panel/pinned') as any;
+            return panel ? panel.id : null;
+        }
     }
-
-    // ❌ this is bad because it's tappnig directly into the store circumventing the API
-    // this will work, but if the store changes strcture, it might break 👇
-    get pinned(): string | null {
-        const panel = this.$store.get<PanelInstance | null>('panel/pinned')!;
-        return panel ? panel.id : null;
-    }
-
-    pinPanel(): void {
-        // ❌ this is bad because it's tappnig directly into the store circumventing the API
-        // this will work, but if the store changes structure, it might break 👇
-        const panel = this.$store.get<PanelInstance>(`panel/items@p1`)!;
-        this.$store.set('panel/pinned', this.pinned !== 'p1' ? panel : null);
-    }
-}
+});
 </script>
 
 <style lang="scss" scoped></style>

--- a/packages/ramp-core/src/fixtures/gazebo/p2-screen-1.vue
+++ b/packages/ramp-core/src/fixtures/gazebo/p2-screen-1.vue
@@ -8,11 +8,7 @@
             <!-- <pin> is a global button component that any fixture/panel/screen can reuse -->
 
             <!-- ✔ this is the correct way to pin a panel and bind the button active state whether this panel is pinned or not 👇 -->
-            <pin
-                @click="panel.pin(!isPinned)"
-                :active="isPinned"
-                v-if="$iApi.screenSize !== 'xs'"
-            ></pin>
+            <pin @click="panel.pin(!isPinned)" :active="isPinned" v-if="checkScreenSize"></pin>
 
             <!-- ✔ this will also work 👇 -->
             <!-- <pin @click="panel.pin(!panel.isPinned)" :active="panel.isPinned"></pin> -->
@@ -49,26 +45,26 @@
 </template>
 
 <script lang="ts">
-import { Vue, Prop } from 'vue-property-decorator';
-
+import { defineComponent, PropType } from 'vue';
 import { PanelInstance } from '@/api';
 
-export default class GazeboP2Screen1V extends Vue {
-    // ✔ this prop is always present and it's set by the panel-container component
-    @Prop() panel!: PanelInstance;
-
-    // ✔ this prop is passed to this component as part of the `route` property when switching/rendering this screen
-    @Prop() greeting?: string;
-
-    // ✔ create a computer property from the `pinned` value exposed on the API
-    // TODO: if there many similar pieces of code that repeat often, we can pull them out into a mixin
-    get isPinned(): boolean {
-        return this.panel.isPinned;
-
-        // ✔ this also works 👇
-        // return this.$iApi.panel.pinned !== null && this.$iApi.panel.pinned.id === this.panel.id;
+export default defineComponent({
+    name: 'GazeboP2Screen1V',
+    props: {
+        panel: { type: Object as PropType<PanelInstance>, required: true },
+        greeting: { type: String }
+    },
+    computed: {
+        isPinned(): boolean {
+            return this.panel.isPinned;
+            // ✔ this also works 👇
+            // return this.$iApi.panel.pinned !== null && this.$iApi.panel.pinned.id === this.panel.id;
+        },
+        checkScreenSize(): boolean {
+            return this.$iApi.screenSize !== 'xs';
+        }
     }
-}
+});
 </script>
 
 <style lang="scss" scoped></style>

--- a/packages/ramp-core/src/fixtures/gazebo/p2-screen-2.vue
+++ b/packages/ramp-core/src/fixtures/gazebo/p2-screen-2.vue
@@ -8,11 +8,7 @@
             <!-- <pin> is a global button component that any fixture/panel/screen can reuse -->
 
             <!-- ✔ this is the correct way to pin a panel and bind the button active state whether this panel is pinned or not 👇 -->
-            <pin
-                @click="panel.pin()"
-                :active="isPinned"
-                v-if="$iApi.screenSize !== 'xs'"
-            ></pin>
+            <pin @click="panel.pin()" :active="isPinned" v-if="checkScreenSize"></pin>
 
             <!-- ✔ this will also work 👇 -->
             <!-- <pin @click="panel.pin()" :active="panel.isPinned"></pin> -->
@@ -50,32 +46,33 @@
 </template>
 
 <script lang="ts">
-import { Vue, Prop } from 'vue-property-decorator';
-
+import { defineComponent, PropType } from 'vue';
 import { PanelInstance } from '@/api';
 
-export default class GazeboP2Screen2V extends Vue {
-    // ✔ this prop is always present and it's set by the panel-container component
-    @Prop() panel!: PanelInstance;
-
-    // ✔ this prop is passed to this component as part of the `route` property when switching/rendering this screen
-    @Prop() greeting?: string;
-
-    // ✔ create a computer property from the `pinned` value exposed on the API
-    // TODO: if there many similar pieces of code that repeat often, we can pull them out into a mixin
-    get isPinned(): boolean {
-        return this.panel.isPinned;
-
-        // ✔ this also works 👇
-        // return this.$iApi.panel.pinned !== null && this.$iApi.panel.pinned.id === this.panel.id;
+export default defineComponent({
+    name: 'GazeboP2Screen2V',
+    props: {
+        panel: { type: Object as PropType<PanelInstance>, required: true },
+        greeting: { type: String }
+    },
+    computed: {
+        isPinned(): boolean {
+            return this.panel.isPinned;
+            // ✔ this also works 👇
+            // return this.$iApi.panel.pinned !== null && this.$iApi.panel.pinned.id === this.panel.id;
+        },
+        checkScreenSize(): boolean {
+            return this.$iApi.screenSize !== 'xs';
+        }
+    },
+    methods: {
+        enhancedCatActivities() {
+            // shows a cat, also does an event API flex
+            this.panel.show('p-2-screen-3');
+            this.$iApi.event.emit('gazebo/beholdMyText', 'I am a cat');
+        }
     }
-
-    enhancedCatActivities() {
-        // shows a cat, also does an event API flex
-        this.panel.show('p-2-screen-3');
-        this.$iApi.event.emit('gazebo/beholdMyText', 'I am a cat');
-    }
-}
+});
 </script>
 
 <style lang="scss" scoped></style>

--- a/packages/ramp-core/src/fixtures/gazebo/p2-screen-3.vue
+++ b/packages/ramp-core/src/fixtures/gazebo/p2-screen-3.vue
@@ -6,18 +6,11 @@
             <!-- <pin> is a global button component that any fixture/panel/screen can reuse -->
 
             <!-- ✔ this is the correct way to pin a panel and bind the button active state whether this panel is pinned or not 👇 -->
-            <pin
-                @click="panel.pin()"
-                :active="panel.isPinned"
-                v-if="$iApi.screenSize !== 'xs'"
-            ></pin>
+            <pin @click="panel.pin()" :active="panel.isPinned" v-if="checkScreenSize"></pin>
 
             <!-- ✔ this will also work 👇 -->
             <!-- <pin @click="panel.pin()" :active="panel.isPinned"></pin> -->
-            <close
-                @click="panel.close()"
-                v-if="$iApi.screenSize !== 'xs'"
-            ></close>
+            <close @click="panel.close()" v-if="checkScreenSize"></close>
         </template>
 
         <template #content>
@@ -36,7 +29,6 @@
                 </button>
 
                 <img
-                    width="250px"
                     class="my-16"
                     src="https://media.giphy.com/media/iWkHDNtcHpB5e/giphy.gif"
                     alt=""
@@ -46,7 +38,7 @@
                 <p>Locale merging:</p>
                 <dl>
                     <dt>global locale:</dt>
-                    <dd class="ml-32 font-bold">{{ $t('lang-native') }}</dd>
+                    <dd class="ml-32 font-bold">{{ $t('lang_native') }}</dd>
                     <dt>fixture locale:</dt>
                     <dd class="ml-32 font-bold">{{ $t('gz.hello') }}</dd>
                     <dt>common panels locale:</dt>
@@ -58,23 +50,32 @@
 </template>
 
 <script lang="ts">
-import { Vue, Options, Prop } from 'vue-property-decorator';
-
+import { defineComponent, PropType } from 'vue';
 import { PanelInstance } from '@/api';
 
-@Options({
+export default defineComponent({
+    name: 'GazeboP2Screen3V',
+    props: {
+        panel: { type: Object as PropType<PanelInstance>, required: true }
+    },
     i18n: {
         messages: {
             en: {
+                lang_native: 'En',
                 who: '[me cat]'
+            },
+            fr: {
+                lang_native: 'Fr',
+                who: '[moi chat]'
             }
         }
+    },
+    computed: {
+        checkScreenSize(): boolean {
+            return this.$iApi.screenSize !== 'xs';
+        }
     }
-})
-export default class GazeboP2Screen3V extends Vue {
-    // ✔ this prop is always present and it's set by the panel-container component
-    @Prop() panel!: PanelInstance;
-}
+});
 </script>
 
 <style lang="scss" scoped></style>


### PR DESCRIPTION
## Fixes in this PR
- Gazebo fixture now loads and functions properly
- Migrated all Gazebo screens to use `defineComponent`

## Further work/comments/questions
- **Further Work:**
    - Migrate Vue2 Gazebo loading methods to Vue3 (~~TODO: Add issue to backlog~~ ✔)

## Steps to test
[Demo - Panel Party](http://ramp4-app.azureedge.net/demo/users/sharvenp/vue3-gazebo-fixture/host/index-e2e.html?script=panel-party)

1. Load Demo
2. Open the Gazebo panel and navigate through its buttons (don't forget to see the cat!)
3. Switch the language - the panel should update its text
    - Note that this will throw some warnings about language keys not found - this is expected.