### PR TITLE
Final wizard changes - lifecycle hook, fix warnings, special cases

### DIFF
--- a/packages/ramp-core/src/fixtures/wizard/form-input.vue
+++ b/packages/ramp-core/src/fixtures/wizard/form-input.vue
@@ -160,8 +160,8 @@ export default defineComponent({
             default: false
         },
         modelValue: {
-            type: [String, Boolean],
-            default: false
+            type: [String, Array],
+            default: ''
         },
         name: {
             type: [String, Boolean],


### PR DESCRIPTION
[Demo](http://ramp4-app.azureedge.net/demo/users/yileifeng/vue3-wizard-errors/host/index.html)

**Changes**: 
- changes to `errorCaptured` lifehook and select step to handle errors when incorrectly selecting a feature layer type
- fixed `modelValue` incorrect prop type console warnings for `layerEntries`
- handle some edge cases where errors remained when switching back and forth in the stepper + cases where continue button should not be enabled
- fix prod build issues

**Testing**: 
- test that a non-feature layer (MapImage or WMS) will trigger an error when selecting its service type as `ESRI Feature`
- ensure that after an incorrect service type is selected, the correct type can still be selected to advance to the configure step (this was the case that triggered prod build errors)
- check that there are no longer any repeated console errors/warnings

Afterwards, test all different cases you can think of to break the wizard and let me know if you find anything (or even simple UI enhancements) as I would like to include all final wizard fixes in this PR if possible.  
