### PR TITLE
fix component loading methods

### DIFF
--- a/packages/ramp-core/src/api/common.ts
+++ b/packages/ramp-core/src/api/common.ts
@@ -63,12 +63,10 @@ export interface AppVersion {
  * @param {(VueConstructor | any)} value
  * @returns {value is VueConstructor}
  */
-export function isVueConstructor(
-    value: typeof createApp | unknown
-): value is typeof createApp {
+export function isVueConstructor(value: any): any {
     // check if the value itself is a function (it's not possible to tell if it's a constructor function or not)
-    // check if value's prototype is an instance of Vue--this is the important check
-    return typeof value === 'function';
+    // check if the value has a render function. May not be foolproof, but there doesn't seem like a better way.
+    return typeof value === 'function' && value.render && typeof value.render === 'function';
 }
 
 /**
@@ -94,11 +92,7 @@ export function isComponentOptions(value: any): value is ComponentOptions {
         'model'
     ];
 
-    return (
-        typeof value === 'object' &&
-        !value.functional &&
-        names.some(name => value[name] !== undefined)
-    );
+    return typeof value === 'object' && !value.functional && names.some(name => value[name] !== undefined);
 }
 
 /**
@@ -107,8 +101,6 @@ export function isComponentOptions(value: any): value is ComponentOptions {
  * @param {(typeof import('*.vue') | any)} value
  * @returns {value is typeof import('*.vue')}
  */
-export function isTypeofImportVue(
-    value: typeof import('*.vue') | any
-): value is typeof import('*.vue') {
+export function isTypeofImportVue(value: typeof import('*.vue') | any): value is typeof import('*.vue') {
     return typeof value === 'object' && value.default !== undefined;
 }

--- a/packages/ramp-core/src/fixtures/gazebo/index.ts
+++ b/packages/ramp-core/src/fixtures/gazebo/index.ts
@@ -1,4 +1,5 @@
 import { FixtureInstance } from '@/api';
+import { AsyncComponentEh } from '@/store/modules/panel';
 
 import GazeboAppbarButtonV from './appbar-button.vue';
 
@@ -59,43 +60,39 @@ class GazeboFixture extends FixtureInstance {
                          * // TODO: This should work:
                          * manually lazy-loading a screen component
                          */
-                        // 'p-2-screen-1': () => import(/* webpackChunkName: "p-2-screen-1" */ `./p2-screen-1.vue`),
+                        //'p-2-screen-1': () => import(/* webpackChunkName: "p-2-screen-1" */ `./p2-screen-1.vue`),
 
                         /**
                          * // TODO: This should work:
                          * for the demo purposes, delay resolution of a component by 2 seconds
                          */
-                        // 'p-2-screen-1': () => {
-                        //     return new Promise<AsyncComponentEh>(resolve =>
-                        //         setTimeout(
-                        //             () =>
-                        //                 import(
-                        //                     /* webpackChunkName: "p-2-screen-1" */ `./p2-screen-1.vue`
-                        //                 ).then(data => {
-                        //                     resolve(data);
-                        //                 }),
-                        //             2000
-                        //         )
-                        //     );
-                        // },
+                        'p-2-screen-1': () => {
+                            return new Promise<AsyncComponentEh>(resolve =>
+                                setTimeout(
+                                    () =>
+                                        import(/* webpackChunkName: "p-2-screen-1" */ `./p2-screen-1.vue`).then(
+                                            data => {
+                                                resolve(data);
+                                            }
+                                        ),
+                                    2000
+                                )
+                            );
+                        },
 
                         /**
                          * // TODO: This should work:
                          * letting the core to lazy-load a screen component; need to provide a path relative to the fixtures home folder
                          */
-                        // 'p-2-screen-2': 'gazebo/p2-screen-2.vue',
-
-                        'p-2-screen-1': GazeboP2Screen1V,
-                        'p-2-screen-2': GazeboP2Screen2V,
-                        'p-2-screen-3': GazeboP2Screen3V
+                        'p-2-screen-2': 'gazebo/p2-screen-2.vue',
 
                         /**
                          * // TODO: This should work:
                          * returning a `VueConstructor` in a promise
                          */
-                        // 'p-2-screen-3': () => {
-                        //     return new Promise<AsyncComponentEh>(resolve => resolve(GazeboP2Screen3V));
-                        // }
+                        'p-2-screen-3': () => {
+                            return new Promise<AsyncComponentEh>(resolve => resolve(GazeboP2Screen3V));
+                        }
                     },
                     style: {
                         'flex-grow': '1',


### PR DESCRIPTION
**Changes in this PR**
- fixed the different component loading methods
- changed Gazebo fixture to use these different loading methods

**Concerns**
None

**Testing this PR**
You can find a demo for this PR [here](http://ramp4-app.azureedge.net/demo/users/RyanCoulsonCA/vue3-fix-component-load/host/index-e2e.html?script=panel-party).

To test, simply make sure the gazebo screens are loading correctly.

