### PR TITLE
Refactor remaining components using defineComponent and clean up imports

### DIFF
--- a/packages/ramp-core/src/components/map/esri-map.vue
+++ b/packages/ramp-core/src/components/map/esri-map.vue
@@ -16,9 +16,7 @@
 </template>
 
 <script lang="ts">
-import { ComputedRef } from 'vue';
-import { Vue, Watch } from 'vue-property-decorator';
-import { Get } from 'vuex-pathify';
+import { defineComponent, ref } from 'vue';
 import { get } from '@/store/pathify-helper';
 import { RampLayerConfig, RampMapConfig } from '@/geo/api';
 import { GlobalEvents, LayerInstance, MapAPI } from '@/api/internal';
@@ -29,145 +27,148 @@ import { LayerStore } from '@/store/modules/layer';
 import to from 'await-to-js';
 import { MaptipStore } from '@/store/modules/maptip';
 
-export default class EsriMapV extends Vue {
-    mapConfig: ComputedRef<RampMapConfig> = get(ConfigStore.getMapConfig);
-    // @Get(ConfigStore.getMapConfig) mapConfig!: RampMapConfig;
-
-    layers: ComputedRef<LayerInstance[]> = get(LayerStore.layers);
-    // @Get(LayerStore.layers) layers!: LayerInstance[];
-
-    layerConfigs: ComputedRef<RampLayerConfig[]> = get(LayerStore.layerConfigs);
-    // @Get(LayerStore.layerConfigs) layerConfigs!: RampLayerConfig[];
-
-    maptipProperties: any = get(MaptipStore.maptipProperties);
-    // @Get(MaptipStore.maptipProperties) maptipProperties!: any;
-    maptipInstance: any = get(MaptipStore.maptipInstance);
-    // @Get(MaptipStore.maptipInstance) maptipInstance!: any;
-
-    map!: MapAPI; // TODO assuming we need this as a local property for vue binding. if we don't, remove it and just use $iApi.geo.map
+export default defineComponent({
+    name: 'EsriMapV',
+    data() {
+        return {
+            mapConfig: get(ConfigStore.getMapConfig),
+            layers: get(LayerStore.layers),
+            layerConfigs: get(LayerStore.layerConfigs),
+            maptipProperties: get(MaptipStore.maptipProperties),
+            maptipInstance: get(MaptipStore.maptipInstance),
+            map: ref() // TODO assuming we need this as a local property for vue binding. if we don't, remove it and just use $iApi.geo.map
+        };
+    },
 
     created() {
         // temporarily print out loaded layers to console for grid testing purposes.
         console.log(this.layers, this.mapConfig);
-    }
+    },
 
-    @Watch('maptipProperties')
-    onMaptipChange() {
-        if (this.maptipProperties) {
-            // Calculate offset from mappoint
-            let offsetX, offsetY: number;
-            const originX: number = this.$iApi.geo.map.getPixelWidth() / 2;
-            const originY: number = 0;
-            const screenPointFromMapPoint = this.$iApi.geo.map.mapPointToScreenPoint(
-                this.maptipProperties.mapPoint
-            );
-            offsetX = screenPointFromMapPoint.screenX - originX;
-            offsetY = originY - screenPointFromMapPoint.screenY;
-            this.maptipInstance.setProps({
-                offset: [offsetX, offsetY]
-            });
-            this.maptipInstance.show();
-        } else {
-            this.maptipInstance.hide();
-        }
-    }
+    watch: {
+        maptipProperties() {
+            if (this.maptipProperties) {
+                // Calculate offset from mappoint
+                let offsetX, offsetY: number;
+                const originX: number = this.$iApi.geo.map.getPixelWidth() / 2;
+                const originY: number = 0;
+                const screenPointFromMapPoint = this.$iApi.geo.map.mapPointToScreenPoint(
+                    this.maptipProperties.mapPoint
+                );
+                offsetX = screenPointFromMapPoint.screenX - originX;
+                offsetY = originY - screenPointFromMapPoint.screenY;
+                this.maptipInstance.setProps({
+                    offset: [offsetX, offsetY]
+                });
+                this.maptipInstance.show();
+            } else {
+                this.maptipInstance.hide();
+            }
+        },
 
-    @Watch('layerConfigs')
-    async onLayerConfigArrayChange(newValue: RampLayerConfig[], oldValue: RampLayerConfig[]) {
-        console.log('Saw layer config change', oldValue, newValue, !!this.map);
+        layerConfigs(newValue: RampLayerConfig[], oldValue: RampLayerConfig[]) {
+            this.onLayerConfigArrayChange(newValue, oldValue);
+        },
 
-        // TODO we are getting frequent errors at startup; something reacts to layer array
-        //      change before map exists. kicking out for now to make demos work.
-        //      possibly this is evil in vue state land. if so, then someone figure out
-        //      the root cause and fix that.
-        if (!this.map || !newValue) {
-            return;
-        }
+        mapConfig(newValue: RampMapConfig, oldValue: RampMapConfig) {
+            console.log('new map config change: ', newValue, this.mapConfig);
+            if (newValue === oldValue) {
+                return;
+            }
 
-        const layers = await Promise.all(
-            newValue
-                .filter(lc => !oldValue.includes(lc))
-                .map(layerConfig => {
-                    return new Promise<LayerInstance | null>(async resolve => {
-                        let defLoadProm: Promise<string>;
+            const mapViewElement: Element | null = this.$el;
 
-                        // check if we need to load the layer class
-                        if (this.$iApi.geo.layer.layerDefExists(layerConfig.layerType)) {
-                            defLoadProm = Promise.resolve(layerConfig.layerType);
-                        } else {
-                            // if the definition is a custom number, the site host would have had to add the
-                            // definition already. this block should only run for layer types that are bundled
-                            // in the ramp core codebase.
-                            defLoadProm = this.$iApi.geo.layer.addLayerDef(layerConfig.layerType);
-                        }
+            this.$iApi.geo.map.createMap(newValue, mapViewElement as HTMLDivElement);
+            this.map = this.$iApi.geo.map;
+            this.$iApi.event.emit(GlobalEvents.MAP_CREATED, this.$iApi.geo.map);
 
-                        // wait for definition to load, or ride the resolve if already loaded
-                        await defLoadProm;
-                        // create the layer instantiation
-                        const [createErr, layer] = await to(
-                            this.$iApi.geo.layer.createLayer(layerConfig)
-                        );
-
-                        if (createErr) {
-                            console.error(createErr);
-                            resolve(null);
-                            return;
-                        }
-
-                        // TODO call the new layer load method.
-                        //      might need to wait on that (think file layers that are making asynch calls prior to creating esri layer)
-                        //      see if layers are going to expose an "esri layer exists" promise, leverage that if they do
-                        const [initiateErr] = await to(layer!.initiate());
-                        if (initiateErr) {
-                            console.error(initiateErr);
-                        } else {
-                            this.map.addLayer(layer!);
-                        }
-
-                        // add layers to layer store
-                        // TODO need to revisit https://github.com/ramp4-pcar4/ramp4-pcar4/discussions/328
-                        //      as we may be causing lots of problems putting these objects in vuex store.
-                        this.$iApi.$vApp.$store.set(LayerStore.addLayers, [layer]);
-
-                        resolve(layer!);
-                    });
-                })
-        );
-
-        // need to wait for all layers before reordering since esri reorder does
-        // not allow reordering/inserting into arbitrary indices (i.e. no holes)
-        layers.filter(Boolean).forEach((layer: LayerInstance | null, index: number) => {
-            this.$iApi.geo.map.reorder(layer!, oldValue.length + index);
-        });
-    }
-
-    @Watch('mapConfig')
-    onMapConfigChange(newValue: RampMapConfig, oldValue: RampMapConfig) {
-        console.log('new map config change: ', newValue, this.mapConfig);
-        if (newValue === oldValue) {
-            return;
-        }
-
-        const mapViewElement: Element | null = this.$el;
-
-        this.$iApi.geo.map.createMap(newValue, mapViewElement as HTMLDivElement);
-        this.map = this.$iApi.geo.map;
-        this.$iApi.event.emit(GlobalEvents.MAP_CREATED, this.$iApi.geo.map);
-
-        // Hide hovertip on map creation
-        //@ts-ignore
-        mapViewElement._tippy.hide(0);
-        this.$iApi.$vApp.$store.set(
-            MaptipStore.setMaptipInstance,
+            // Hide hovertip on map creation
             //@ts-ignore
-            mapViewElement._tippy
-        );
+            mapViewElement._tippy.hide(0);
+            this.$iApi.$vApp.$store.set(
+                MaptipStore.setMaptipInstance,
+                //@ts-ignore
+                mapViewElement._tippy
+            );
 
-        // TODO see if we still need this. map config should trigger the array watcher due to the store.
-        //      possibly layer config is processed before map config is done creating map?
-        this.onLayerConfigArrayChange(this.layerConfigs.value, []);
+            // TODO see if we still need this. map config should trigger the array watcher due to the store.
+            //      possibly layer config is processed before map config is done creating map?
+            this.onLayerConfigArrayChange(this.layerConfigs.value, []);
+        }
+    },
+
+    methods: {
+        async onLayerConfigArrayChange(newValue: RampLayerConfig[], oldValue: RampLayerConfig[]) {
+            console.log('Saw layer config change', oldValue, newValue, !!this.map);
+
+            // TODO we are getting frequent errors at startup; something reacts to layer array
+            //      change before map exists. kicking out for now to make demos work.
+            //      possibly this is evil in vue state land. if so, then someone figure out
+            //      the root cause and fix that.
+            if (!this.map || !newValue) {
+                return;
+            }
+
+            const layers = await Promise.all(
+                newValue
+                    .filter(lc => !oldValue.includes(lc))
+                    .map(layerConfig => {
+                        return new Promise<LayerInstance | null>(async resolve => {
+                            let defLoadProm: Promise<string>;
+
+                            // check if we need to load the layer class
+                            if (this.$iApi.geo.layer.layerDefExists(layerConfig.layerType)) {
+                                defLoadProm = Promise.resolve(layerConfig.layerType);
+                            } else {
+                                // if the definition is a custom number, the site host would have had to add the
+                                // definition already. this block should only run for layer types that are bundled
+                                // in the ramp core codebase.
+                                defLoadProm = this.$iApi.geo.layer.addLayerDef(
+                                    layerConfig.layerType
+                                );
+                            }
+
+                            // wait for definition to load, or ride the resolve if already loaded
+                            await defLoadProm;
+                            // create the layer instantiation
+                            const [createErr, layer] = await to(
+                                this.$iApi.geo.layer.createLayer(layerConfig)
+                            );
+
+                            if (createErr) {
+                                console.error(createErr);
+                                resolve(null);
+                                return;
+                            }
+
+                            // TODO call the new layer load method.
+                            //      might need to wait on that (think file layers that are making asynch calls prior to creating esri layer)
+                            //      see if layers are going to expose an "esri layer exists" promise, leverage that if they do
+                            const [initiateErr] = await to(layer!.initiate());
+                            if (initiateErr) {
+                                console.error(initiateErr);
+                            } else {
+                                this.map.addLayer(layer!);
+                            }
+
+                            // add layers to layer store
+                            // TODO need to revisit https://github.com/ramp4-pcar4/ramp4-pcar4/discussions/328
+                            //      as we may be causing lots of problems putting these objects in vuex store.
+                            this.$iApi.$vApp.$store.set(LayerStore.addLayers, [layer]);
+
+                            resolve(layer!);
+                        });
+                    })
+            );
+
+            // need to wait for all layers before reordering since esri reorder does
+            // not allow reordering/inserting into arbitrary indices (i.e. no holes)
+            layers.filter(Boolean).forEach((layer: LayerInstance | null, index: number) => {
+                this.$iApi.geo.map.reorder(layer!, oldValue.length + index);
+            });
+        }
     }
-}
+});
 </script>
 
 <style lang="scss" scoped></style>

--- a/packages/ramp-core/src/components/notification-center/appbar-button.vue
+++ b/packages/ramp-core/src/components/notification-center/appbar-button.vue
@@ -32,7 +32,6 @@ export default defineComponent({
     data() {
         return {
             number: get('notification/notificationNumber')
-            // @Get('notification/notificationNumber') number!: Number;
         };
     },
 

--- a/packages/ramp-core/src/components/notification-center/caption-button.vue
+++ b/packages/ramp-core/src/components/notification-center/caption-button.vue
@@ -57,23 +57,26 @@
 </template>
 
 <script lang="ts">
-import { ComputedRef } from 'vue';
-import { Vue, Options } from 'vue-property-decorator';
+import { defineComponent } from 'vue';
 import { get, call } from '@/store/pathify-helper';
 
 import DropdownMenuV from '@/components/controls/dropdown-menu.vue';
 import NotificationListV from './notification-list.vue';
 
-@Options({
+export default defineComponent({
+    name: 'NotificationsCaptionButtonV',
     components: {
         'dropdown-menu': DropdownMenuV,
         'notification-list': NotificationListV
+    },
+
+    data() {
+        return {
+            number: get('notification/notificationNumber'),
+            clearAll: call('notification/clearAll')
+        };
     }
-})
-export default class NotificationsCaptionButtonV extends Vue {
-    number: ComputedRef<Number> = get('notification/notificationNumber');
-    clearAll: () => void = call('notification/clearAll');
-}
+});
 </script>
 
 <style lang="scss" scoped>

--- a/packages/ramp-core/src/components/notification-center/floating-button.vue
+++ b/packages/ramp-core/src/components/notification-center/floating-button.vue
@@ -9,11 +9,7 @@
         v-tippy
     >
         <!-- https://fonts.google.com/icons?selected=Material%20Icons%3Anotifications -->
-        <svg
-            class="fill-current w-24 h-24"
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 24 24"
-        >
+        <svg class="fill-current w-24 h-24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
             <path
                 d="M12 22c1.1 0 2-.9 2-2h-4c0 1.1.89 2 2 2zm6-6v-5c0-3.07-1.64-5.64-4.5-6.32V4c0-.83-.67-1.5-1.5-1.5s-1.5.67-1.5 1.5v.68C7.63 5.36 6 7.92 6 11v5l-2 2v1h16v-1l-2-2z"
             />
@@ -27,15 +23,17 @@
 </template>
 
 <script lang="ts">
-import { ComputedRef } from 'vue';
-import { Vue } from 'vue-property-decorator';
-import { Get } from 'vuex-pathify';
+import { defineComponent } from 'vue';
 import { get } from '@/store/pathify-helper';
 
-export default class NotificationsFloatingButtonV extends Vue {
-    number: ComputedRef<Number> = get('notification/notificationNumber');
-    // @Get('notification/notificationNumber') number!: Number;
-}
+export default defineComponent({
+    name: 'NotificationsFloatingButtonV',
+    data() {
+        return {
+            number: get('notification/notificationNumber')
+        };
+    }
+});
 </script>
 
 <style lang="scss" scoped>

--- a/packages/ramp-core/src/components/notification-center/notification-item.vue
+++ b/packages/ramp-core/src/components/notification-center/notification-item.vue
@@ -52,29 +52,40 @@
 </template>
 
 <script lang="ts">
-import { Vue, Prop } from 'vue-property-decorator';
+import { defineComponent } from 'vue';
 import { call } from '@/store/pathify-helper';
 
 import { NotificationType } from '@/api/notifications';
 
-export default class NotificationListV extends Vue {
-    @Prop() notification!: any;
-    removeNotification: (notification: any) => void = call('notification/removeNotification');
+export default defineComponent({
+    name: 'NotificationListV',
+    props: {
+        notification: {
+            type: Object,
+            required: true
+        }
+    },
 
-    open: boolean = false;
+    data() {
+        return {
+            removeNotification: call('notification/removeNotification'),
+            open: false,
+            icons: {
+                [NotificationType.WARNING]: '⚠',
+                [NotificationType.INFO]: '☑',
+                [NotificationType.ERROR]: '❌'
+            }
+        };
+    },
 
-    icons = {
-        [NotificationType.WARNING]: '⚠',
-        [NotificationType.INFO]: '☑',
-        [NotificationType.ERROR]: '❌'
-    };
-
-    tooltipShow() {
-        if (!this.notification.messageList) {
-            return false;
+    methods: {
+        tooltipShow() {
+            if (!this.notification.messageList) {
+                return false;
+            }
         }
     }
-}
+});
 </script>
 
 <style lang="scss"></style>

--- a/packages/ramp-core/src/components/notification-center/notification-list.vue
+++ b/packages/ramp-core/src/components/notification-center/notification-list.vue
@@ -16,11 +16,7 @@
     <!-- No Notifications -->
     <div v-else class="flex flex-col items-center h-full">
         <span class="flex-grow" />
-        <svg
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 24 24"
-            class="h-48 w-48 fill-current"
-        >
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="h-48 w-48 fill-current">
             <path d="M0 0h24v24H0z" fill="none" />
             <path
                 d="M18 7l-1.41-1.41-6.34 6.34 1.41 1.41L18 7zm4.24-1.41L11.66 16.17 7.48 12l-1.41 1.41L11.66 19l12-12-1.42-1.41zM.41 13.41L6 19l1.41-1.41L1.83 12 .41 13.41z"
@@ -32,24 +28,23 @@
 </template>
 
 <script lang="ts">
-import { ComputedRef } from 'vue';
-import { Vue, Options } from 'vue-property-decorator';
-import { Get } from 'vuex-pathify';
+import { defineComponent } from 'vue';
 import { get } from '@/store/pathify-helper';
 
 import NotificationItemV from './notification-item.vue';
 
-@Options({
+export default defineComponent({
+    name: 'NotificationListV',
     components: {
         'notification-item': NotificationItemV
+    },
+
+    data() {
+        return {
+            notificationStack: get('notification/notificationStack')
+        };
     }
-})
-export default class NotificationListV extends Vue {
-    notificationStack: ComputedRef<any[]> = get(
-        'notification/notificationStack'
-    );
-    // @Get('notification/notificationStack') notificationStack!: any[];
-}
+});
 </script>
 
 <style lang="scss" scoped></style>

--- a/packages/ramp-core/src/components/notification-center/screen.vue
+++ b/packages/ramp-core/src/components/notification-center/screen.vue
@@ -5,7 +5,7 @@
         </template>
 
         <template #controls>
-            <pin @click="panel.pin()" :active="isPinned"></pin>
+            <pin @click="panel.pin()" :active="isPinned()"></pin>
             <close @click="panel.close()"></close>
         </template>
 
@@ -36,27 +36,38 @@
 </template>
 
 <script lang="ts">
-import { Vue, Options, Prop } from 'vue-property-decorator';
+import { defineComponent, PropType } from 'vue';
 import { call } from '@/store/pathify-helper';
 
 import { PanelInstance } from '@/api';
 
 import NotificationListV from './notification-list.vue';
 
-@Options({
+export default defineComponent({
+    name: 'NotificationsScreenV',
+    props: {
+        panel: {
+            type: Object as PropType<PanelInstance>,
+            required: true
+        }
+    },
+
     components: {
         'notification-list': NotificationListV
-    }
-})
-export default class NotificationsScreenV extends Vue {
-    @Prop() panel!: PanelInstance;
+    },
 
-    clearAll: () => void = call('notification/clearAll');
+    data() {
+        return {
+            clearAll: call('notification/clearAll')
+        };
+    },
 
-    get isPinned(): boolean {
-        return this.panel.isPinned;
+    methods: {
+        isPinned(): boolean {
+            return this.panel.isPinned;
+        }
     }
-}
+});
 </script>
 
 <style lang="scss"></style>

--- a/packages/ramp-core/src/components/panel-stack/controls/back.vue
+++ b/packages/ramp-core/src/components/panel-stack/controls/back.vue
@@ -21,11 +21,17 @@
 </template>
 
 <script lang="ts">
-import { Vue, Prop } from 'vue-property-decorator';
+import { defineComponent } from 'vue';
 
-export default class BackV extends Vue {
-    @Prop() active!: boolean;
-}
+export default defineComponent({
+    name: 'BackV',
+    props: {
+        active: {
+            type: Boolean,
+            required: true
+        }
+    }
+});
 </script>
 
 <style lang="scss" scoped></style>

--- a/packages/ramp-core/src/components/panel-stack/controls/close.vue
+++ b/packages/ramp-core/src/components/panel-stack/controls/close.vue
@@ -20,11 +20,14 @@
 </template>
 
 <script lang="ts">
-import { Vue, Prop } from 'vue-property-decorator';
+import { defineComponent } from 'vue';
 
-export default class CloseV extends Vue {
-    @Prop() active!: boolean;
-}
+export default defineComponent({
+    name: 'CloseV',
+    props: {
+        active: Boolean
+    }
+});
 </script>
 
 <style lang="scss" scoped></style>

--- a/packages/ramp-core/src/components/panel-stack/controls/minimize.vue
+++ b/packages/ramp-core/src/components/panel-stack/controls/minimize.vue
@@ -19,11 +19,17 @@
 </template>
 
 <script lang="ts">
-import { Vue, Prop } from 'vue-property-decorator';
+import { defineComponent } from 'vue';
 
-export default class MinimizeV extends Vue {
-    @Prop() active!: boolean;
-}
+export default defineComponent({
+    name: 'MinimizeV',
+    props: {
+        active: {
+            type: Boolean,
+            required: true
+        }
+    }
+});
 </script>
 
 <style lang="scss" scoped></style>

--- a/packages/ramp-core/src/components/panel-stack/controls/panel-options-menu.vue
+++ b/packages/ramp-core/src/components/panel-stack/controls/panel-options-menu.vue
@@ -1,8 +1,5 @@
 <template>
-    <dropdown-menu
-        class="relative"
-        :tooltip="$t('panels.controls.optionsMenu')"
-    >
+    <dropdown-menu class="relative" :tooltip="$t('panels.controls.optionsMenu')">
         <template #header>
             <div class="p-8">
                 <svg
@@ -21,21 +18,21 @@
 </template>
 
 <script lang="ts">
-import { Vue, Options } from 'vue-property-decorator';
+import { defineComponent } from 'vue';
 import DropdownMenuV from '@/components/controls/dropdown-menu.vue';
 
-@Options({
+export default defineComponent({
+    name: 'PanelOptionsMenuV',
     components: {
         'dropdown-menu': DropdownMenuV
-    }
-})
-export default class PanelOptionsMenuV extends Vue {
+    },
+
     data() {
         return {
             open: false
         };
     }
-}
+});
 </script>
 
 <style lang="scss" scoped></style>

--- a/packages/ramp-core/src/components/panel-stack/controls/pin.vue
+++ b/packages/ramp-core/src/components/panel-stack/controls/pin.vue
@@ -21,11 +21,17 @@
 </template>
 
 <script lang="ts">
-import { Vue, Prop } from 'vue-property-decorator';
+import { defineComponent } from 'vue';
 
-export default class PinV extends Vue {
-    @Prop() active!: boolean;
-}
+export default defineComponent({
+    name: 'PinV',
+    props: {
+        active: {
+            type: Boolean,
+            required: true
+        }
+    }
+});
 </script>
 
 <style lang="scss" scoped></style>

--- a/packages/ramp-core/src/components/panel-stack/panel-container.vue
+++ b/packages/ramp-core/src/components/panel-stack/panel-container.vue
@@ -19,63 +19,73 @@
 </template>
 
 <script lang="ts">
-import { Vue, Prop } from 'vue-property-decorator';
+import { defineComponent, PropType } from 'vue';
 
 import anime from 'animejs';
 
 import { PanelInstance } from '@/api';
 
-export default class PanelContainerV extends Vue {
-    @Prop() panel!: PanelInstance;
-
-    /**
-     * Indicates if the transition should be skipped.
-     */
-    skipTransition: boolean = false;
-
-    enter(el: HTMLElement, done: () => void): void {
-        this.animateTransition(el, done, [0, 1]);
-    }
-
-    beforeLeave(el: HTMLElement): void {
-        // this will also trigger when the loading component is transitioning out; in such cases skip executing this function
-        if (el.classList.contains('screen-spinner')) {
-            return;
+export default defineComponent({
+    name: 'PanelContainerV',
+    props: {
+        panel: {
+            type: Object as PropType<PanelInstance>,
+            required: true
         }
+    },
 
-        // if the screen component is already loaded; if so, skip the transition
-        this.skipTransition = this.panel.isScreenLoaded(this.panel.route.screen);
+    data() {
+        return {
+            // indicates if the transition should be skipped
+            skipTransition: false
+        };
+    },
 
-        // with transition, even if it's instanteneous, there is that annoying flicker when the focus ring is set
-        // just before the component is removed from DOM; supress the focus ring on the screen component just before `leave` event
-        this.$el
-            .querySelectorAll('[focus-item')
-            .forEach((element: HTMLElement) => element.classList.remove('default-focus-style'));
-    }
+    methods: {
+        enter(el: HTMLElement, done: () => void): void {
+            this.animateTransition(el, done, [0, 1]);
+        },
 
-    leave(el: HTMLElement, done: () => void): void {
-        this.animateTransition(el, done, [1, 0]);
-    }
+        beforeLeave(el: HTMLElement): void {
+            // this will also trigger when the loading component is transitioning out; in such cases skip executing this function
+            if (el.classList.contains('screen-spinner')) {
+                return;
+            }
 
-    /**
-     * Animate transition between panel screen components by fading them in/out.
-     */
-    animateTransition(el: HTMLElement, done: () => void, value: number[]): void {
-        if (this.skipTransition) {
-            return done();
+            // if the screen component is already loaded; if so, skip the transition
+            this.skipTransition = this.panel.isScreenLoaded(this.panel.route.screen);
+
+            // with transition, even if it's instanteneous, there is that annoying flicker when the focus ring is set
+            // just before the component is removed from DOM; supress the focus ring on the screen component just before `leave` event
+            this.$el
+                .querySelectorAll('[focus-item')
+                .forEach((element: HTMLElement) => element.classList.remove('default-focus-style'));
+        },
+
+        leave(el: HTMLElement, done: () => void): void {
+            this.animateTransition(el, done, [1, 0]);
+        },
+
+        /**
+         * Animate transition between panel screen components by fading them in/out.
+         */
+        animateTransition(el: HTMLElement, done: () => void, value: number[]): void {
+            if (this.skipTransition) {
+                return done();
+            }
+
+            anime({
+                targets: el,
+                opacity: {
+                    value,
+                    duration: 400,
+                    easing: 'cubicBezier(.5, .05, .1, .3)'
+                },
+                complete: done
+            });
         }
-
-        anime({
-            targets: el,
-            opacity: {
-                value,
-                duration: 400,
-                easing: 'cubicBezier(.5, .05, .1, .3)'
-            },
-            complete: done
-        });
     }
-}
+});
 </script>
 
 <style lang="scss" scoped></style>

--- a/packages/ramp-core/src/components/panel-stack/panel-screen.vue
+++ b/packages/ramp-core/src/components/panel-stack/panel-screen.vue
@@ -28,27 +28,30 @@
 </template>
 
 <script lang="ts">
-import { Vue, Prop } from 'vue-property-decorator';
+import { defineComponent, PropType } from 'vue';
 import { PanelInstance } from '@/api';
 
-export default class PanelScreenV extends Vue {
-    /**
-     * A prop indicating if the `header` slot should be rendered.
-     */
-    @Prop({ default: true }) header!: boolean;
-
-    /**
-     * A prop indicating if the `content` slot should be rendered.
-     */
-    @Prop({ default: true }) content!: boolean;
-
-    /**
-     * A prop indicating if the `footer` slot should be rendered.
-     */
-    @Prop({ default: false }) footer!: boolean;
-
-    @Prop() panel!: PanelInstance;
-}
+export default defineComponent({
+    name: 'PanelScreenV',
+    props: {
+        // prop indicating if the `header` slot should be rendered
+        header: {
+            type: Boolean,
+            default: true
+        },
+        // prop indicating if the `content` slot should be rendered
+        content: {
+            type: Boolean,
+            default: true
+        },
+        // prop indicating if the `footer` slot should be rendered
+        footer: {
+            type: Boolean,
+            default: false
+        },
+        panel: Object as PropType<PanelInstance>
+    }
+});
 </script>
 
 <style lang="scss" scoped></style>

--- a/packages/ramp-core/src/components/panel-stack/panel-stack.vue
+++ b/packages/ramp-core/src/components/panel-stack/panel-stack.vue
@@ -1,10 +1,5 @@
 <template>
-    <transition-group
-        @enter="enter"
-        @leave="leave"
-        name="panel-container"
-        tag="div"
-    >
+    <transition-group @enter="enter" @leave="leave" name="panel-container" tag="div">
         <!-- TODO: pass a corresponding fixture instance to the panel component as it can be useful -->
         <panel-container
             v-for="panel in visible($iApi.screenSize)"
@@ -15,10 +10,8 @@
 </template>
 
 <script lang="ts">
-import { Vue, Options } from 'vue-property-decorator';
-import { Get, Sync } from 'vuex-pathify';
+import { defineComponent } from 'vue';
 import { get, sync } from '@/store/pathify-helper';
-import { ComputedRef, WritableComputedRef } from 'vue';
 
 import anime from 'animejs';
 
@@ -33,20 +26,18 @@ declare class ResizeObserver {
     disconnect(): void;
 }
 
-@Options({
+export default defineComponent({
+    name: 'PanelStackV',
     components: {
         'panel-container': PanelContainerV
-    }
-})
-export default class PanelStackV extends Vue {
-    visible: ComputedRef<(extraSmallScreen: boolean) => PanelInstance[]> = get(
-        'panel/getVisible'
-    );
+    },
 
-    // @Get('panel/getVisible!') visible!: (
-    //     extraSmallScreen: boolean
-    // ) => PanelInstance[];
-    stackWidth: WritableComputedRef<number> = sync('panel/stackWidth');
+    data() {
+        return {
+            visible: get('panel/getVisible'),
+            stackWidth: sync('panel/stackWidth')
+        };
+    },
 
     mounted(): void {
         // sync the `panel-stack` width into the store so that visible can get calculated
@@ -55,60 +46,58 @@ export default class PanelStackV extends Vue {
         });
 
         resizeObserver.observe(this.$el);
+    },
+
+    methods: {
+        enter(el: HTMLElement, done: () => void): void {
+            this.animateTransition(el, done, [
+                [6, 0],
+                [0, 1]
+            ]);
+        },
+
+        leave(el: HTMLElement, done: () => {}): void {
+            const [bbox, pbbox] = [
+                el.children[0].getBoundingClientRect(),
+                el.parentElement!.getBoundingClientRect()
+            ];
+
+            // the panel will be positioned `absolute` and it will screw up its dimensions
+            // to prevent this, set width/height/left manually before detaching the panel
+            el.style.width = `${bbox.width}px`;
+            el.style.height = `${bbox.height}px`;
+            el.style.left = `${bbox.left - pbbox.left}px`;
+
+            // without this, the FLIP transition won't work
+            el.style.position = 'absolute';
+
+            this.animateTransition(el, done, [
+                [0, -6],
+                [1, 0]
+            ]);
+        },
+
+        /**
+         * Animate transition between panel screen components by fading them in/out.
+         */
+        animateTransition(el: HTMLElement, done: () => void, values: number[][]): void {
+            anime({
+                targets: el,
+                duration: 300,
+                translateY: {
+                    value: values[0],
+                    easing: 'cubicBezier(.5, .05, .1, .3)'
+                },
+                opacity: {
+                    value: values[1],
+                    duration: 250,
+                    easing: 'cubicBezier(.5, .05, .1, .3)'
+                },
+                complete: done
+            });
+        }
     }
-
-    enter(el: HTMLElement, done: () => void): void {
-        this.animateTransition(el, done, [
-            [6, 0],
-            [0, 1]
-        ]);
-    }
-
-    leave(el: HTMLElement, done: () => {}): void {
-        const [bbox, pbbox] = [
-            el.children[0].getBoundingClientRect(),
-            el.parentElement!.getBoundingClientRect()
-        ];
-
-        // the panel will be positioned `absolute` and it will screw up its dimensions
-        // to prevent this, set width/height/left manually before detaching the panel
-        el.style.width = `${bbox.width}px`;
-        el.style.height = `${bbox.height}px`;
-        el.style.left = `${bbox.left - pbbox.left}px`;
-
-        // without this, the FLIP transition won't work
-        el.style.position = 'absolute';
-
-        this.animateTransition(el, done, [
-            [0, -6],
-            [1, 0]
-        ]);
-    }
-
-    /**
-     * Animate transition between panel screen components by fading them in/out.
-     */
-    animateTransition(
-        el: HTMLElement,
-        done: () => void,
-        values: number[][]
-    ): void {
-        anime({
-            targets: el,
-            duration: 300,
-            translateY: {
-                value: values[0],
-                easing: 'cubicBezier(.5, .05, .1, .3)'
-            },
-            opacity: {
-                value: values[1],
-                duration: 250,
-                easing: 'cubicBezier(.5, .05, .1, .3)'
-            },
-            complete: done
-        });
-    }
-}
+});
 </script>
 
 <style lang="scss" scoped>

--- a/packages/ramp-core/src/components/panel-stack/screen-spinner.vue
+++ b/packages/ramp-core/src/components/panel-stack/screen-spinner.vue
@@ -8,9 +8,11 @@
 </template>
 
 <script lang="ts">
-import { Vue } from 'vue-property-decorator';
+import { defineComponent } from 'vue';
 
-export default class ScreenSpinnerV extends Vue {}
+export default defineComponent({
+    name: 'ScreenSpinnerV'
+});
 </script>
 
 <style lang="scss" scoped>

--- a/packages/ramp-core/src/components/shell.vue
+++ b/packages/ramp-core/src/components/shell.vue
@@ -15,7 +15,6 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { Vue, Options } from 'vue-property-decorator';
 
 import EsriMapV from '@/components/map/esri-map.vue';
 import PanelStackV from '@/components/panel-stack/panel-stack.vue';

--- a/packages/ramp-core/src/fixtures/appbar/appbar.vue
+++ b/packages/ramp-core/src/fixtures/appbar/appbar.vue
@@ -51,8 +51,6 @@ export default defineComponent({
         return {
             items: get('appbar/visible'),
             temporaryItems: get('appbar/temporary'),
-            // @Get('appbar/visible') items!: AppbarItemInstance[];
-            // @Get('appbar/temporary') temporaryItems!: AppbarItemInstance[];
             overflow: false
         };
     },

--- a/packages/ramp-core/src/fixtures/basemap/nav-button.vue
+++ b/packages/ramp-core/src/fixtures/basemap/nav-button.vue
@@ -11,7 +11,6 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { Vue } from 'vue-property-decorator';
 
 export default defineComponent({
     name: 'BasemapNavButtonV',

--- a/packages/ramp-core/src/fixtures/crosshairs/crosshairs.vue
+++ b/packages/ramp-core/src/fixtures/crosshairs/crosshairs.vue
@@ -48,7 +48,6 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { Vue } from 'vue-property-decorator';
 import { GlobalEvents } from '@/api';
 
 export default defineComponent({

--- a/packages/ramp-core/src/fixtures/details/templates/esri-default.vue
+++ b/packages/ramp-core/src/fixtures/details/templates/esri-default.vue
@@ -2,7 +2,7 @@
     <div>
         <div
             class="p-5 pl-3 flex justify-end flex-wrap even:bg-gray-300"
-            v-for="(val, name, itemIdx) in itemData"
+            v-for="(val, name, itemIdx) in itemData()"
             :key="itemIdx"
         >
             <span class="inline font-bold">{{ name }}</span>
@@ -13,22 +13,29 @@
 </template>
 
 <script lang="ts">
-import { Vue, Prop } from 'vue-property-decorator';
+import { defineComponent, PropType } from 'vue';
 
 import { IdentifyItem } from '@/geo/api';
 
-export default class ESRIDefaultV extends Vue {
-    // passed in by the details panel. Contains all of the identify data.
-    @Prop() identifyData!: IdentifyItem;
+export default defineComponent({
+    name: 'ESRIDefaultV',
+    props: {
+        identifyData: {
+            type: Object as PropType<IdentifyItem>,
+            required: true
+        }
+    },
 
-    // clone identifyData and remove unwanted data
-    get itemData() {
-        const helper: any = {};
-        Object.assign(helper, this.identifyData.data);
-        if (helper.Symbol !== undefined) delete helper.Symbol;
-        return helper;
+    methods: {
+        // clone identifyData and remove unwanted data
+        itemData() {
+            const helper: any = {};
+            Object.assign(helper, this.identifyData.data);
+            if (helper.Symbol !== undefined) delete helper.Symbol;
+            return helper;
+        }
     }
-}
+});
 </script>
 
 <style lang="scss"></style>

--- a/packages/ramp-core/src/fixtures/details/templates/html-default.vue
+++ b/packages/ramp-core/src/fixtures/details/templates/html-default.vue
@@ -8,13 +8,19 @@
 </template>
 
 <script lang="ts">
-import { Vue, Prop } from 'vue-property-decorator';
+import { defineComponent, PropType } from 'vue';
 
 import { IdentifyItem } from '@/geo/api';
 
-export default class HTMLDefaultV extends Vue {
-    @Prop() identifyData!: IdentifyItem;
-}
+export default defineComponent({
+    name: 'HTMLDefaultV',
+    props: {
+        identifyData: {
+            type: Object as PropType<IdentifyItem>,
+            required: true
+        }
+    }
+});
 </script>
 
 <style lang="scss"></style>

--- a/packages/ramp-core/src/fixtures/export-v1/screen.vue
+++ b/packages/ramp-core/src/fixtures/export-v1/screen.vue
@@ -32,17 +32,40 @@
 </template>
 
 <script lang="ts">
-import { Vue, Prop } from 'vue-property-decorator';
+import { defineComponent, PropType } from 'vue';
 
 import { PanelInstance } from '@/api';
 import { ExportV1API } from './api';
 
 import { debounce } from 'throttle-debounce';
 
-export default class ExportV1ScreenV extends Vue {
-    @Prop() panel!: PanelInstance;
+export default defineComponent({
+    name: 'ExportV1ScreenV',
+    props: {
+        panel: {
+            type: Object as PropType<PanelInstance>,
+            required: true
+        }
+    },
 
-    fixture: ExportV1API | null = null;
+    data(): {
+        fixture: ExportV1API | null;
+        make: Function;
+    } {
+        return {
+            fixture: null,
+            make: debounce(300, function(this: any) {
+                if (!this.fixture) {
+                    return;
+                }
+
+                const canvasElement = this.$el.querySelector('.export-canvas') as HTMLCanvasElement;
+
+                // TODO: detect size of the canvas container properly
+                this.fixture.make(canvasElement, this.$el.clientWidth - 16);
+            })
+        };
+    },
 
     mounted() {
         this.fixture = this.$iApi.fixture.get('export-v1') as ExportV1API;
@@ -53,20 +76,7 @@ export default class ExportV1ScreenV extends Vue {
 
         resizeObserver.observe(this.$el);
     }
-
-    make = debounce(300, function(this: ExportV1ScreenV) {
-        if (!this.fixture) {
-            return;
-        }
-
-        const canvasElement = this.$el.querySelector(
-            '.export-canvas'
-        ) as HTMLCanvasElement;
-
-        // TODO: detect size of the canvas container properly
-        this.fixture.make(canvasElement, this.$el.clientWidth - 16);
-    });
-}
+});
 </script>
 
 <style lang="scss" scoped></style>

--- a/packages/ramp-core/src/fixtures/geosearch/search-bar.vue
+++ b/packages/ramp-core/src/fixtures/geosearch/search-bar.vue
@@ -12,8 +12,6 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { Vue } from 'vue-property-decorator';
-import { Get, Call } from 'vuex-pathify';
 import { get, call } from '@/store/pathify-helper';
 import { GeosearchStore } from './store';
 import { debounce } from 'throttle-debounce';

--- a/packages/ramp-core/src/fixtures/grid/screen.vue
+++ b/packages/ramp-core/src/fixtures/grid/screen.vue
@@ -53,8 +53,6 @@
 
 <script lang="ts">
 import { defineComponent, ref } from 'vue';
-import { Vue, Options, Prop } from 'vue-property-decorator';
-import { Get } from 'vuex-pathify';
 import { get } from '@/store/pathify-helper';
 
 import { LayerInstance, PanelInstance } from '@/api';

--- a/packages/ramp-core/src/fixtures/grid/templates/zoom-button-renderer.vue
+++ b/packages/ramp-core/src/fixtures/grid/templates/zoom-button-renderer.vue
@@ -24,7 +24,6 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { Vue } from 'vue-property-decorator';
 import { get } from '@/store/pathify-helper';
 import { LayerInstance } from '@/api/internal';
 import { directive as tippyDirective } from 'vue-tippy';

--- a/packages/ramp-core/src/fixtures/help/nav-button.vue
+++ b/packages/ramp-core/src/fixtures/help/nav-button.vue
@@ -11,7 +11,6 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { Vue } from 'vue-property-decorator';
 import { GlobalEvents } from '../../api/internal';
 
 export default defineComponent({

--- a/packages/ramp-core/src/fixtures/help/screen.vue
+++ b/packages/ramp-core/src/fixtures/help/screen.vue
@@ -5,7 +5,7 @@
         </template>
 
         <template #controls>
-            <pin @click="panel.pin()" :active="isPinned"></pin>
+            <pin @click="panel.pin()" :active="isPinned()"></pin>
             <close @click="panel.close()"></close>
         </template>
 
@@ -20,9 +20,7 @@
 </template>
 
 <script lang="ts">
-import { ComputedRef } from 'vue';
-import { Vue, Options, Prop } from 'vue-property-decorator';
-import { Get } from 'vuex-pathify';
+import { defineComponent, PropType } from 'vue';
 import { get } from '@/store/pathify-helper';
 
 import { PanelInstance } from '@/api';
@@ -33,17 +31,25 @@ import HelpSectionV from './section.vue';
 import axios from 'axios';
 import marked from 'marked';
 
-@Options({
+export default defineComponent({
+    name: 'HelpScreenV',
     components: {
         'help-section': HelpSectionV
-    }
-})
-export default class HelpScreenV extends Vue {
-    @Prop() panel!: PanelInstance;
-    folderName: ComputedRef<string> = get(HelpStore.folderName);
-    // @Get(HelpStore.folderName) folderName!: string;
+    },
 
-    helpSections: any = [];
+    props: {
+        panel: {
+            type: Object as PropType<PanelInstance>,
+            required: true
+        }
+    },
+
+    data() {
+        return {
+            folderName: get(HelpStore.folderName),
+            helpSections: [] as Array<any>
+        };
+    },
 
     mounted() {
         // make help request when fixture loads or locale changes
@@ -92,12 +98,14 @@ export default class HelpScreenV extends Vue {
             },
             { immediate: true }
         );
-    }
+    },
 
-    get isPinned(): boolean {
-        return this.panel.isPinned;
+    methods: {
+        isPinned(): boolean {
+            return this.panel.isPinned;
+        }
     }
-}
+});
 </script>
 
 <style lang="scss" scoped></style>

--- a/packages/ramp-core/src/fixtures/help/section.vue
+++ b/packages/ramp-core/src/fixtures/help/section.vue
@@ -4,25 +4,14 @@
             <button
                 class="help-section-header flex items-center py-15 px-25 hover:bg-gray-200 cursor-pointer select-none w-full"
                 @click="toggleExpanded()"
-                :content="
-                    $t(
-                        expanded
-                            ? 'help.section.collapse'
-                            : 'help.section.expand'
-                    )
-                "
+                :content="$t(expanded ? 'help.section.collapse' : 'help.section.expand')"
                 v-tippy="{ placement: 'top-end', hideOnClick: false }"
             >
                 <!-- name -->
-                <span class="text-lg text-left flex-grow">{{
-                    helpSection.header
-                }}</span>
+                <span class="text-lg text-left flex-grow">{{ helpSection.header }}</span>
 
                 <!-- dropdown icon -->
-                <div
-                    class="icon"
-                    :class="{ 'transform -rotate-180': expanded }"
-                >
+                <div class="icon" :class="{ 'transform -rotate-180': expanded }">
                     <svg
                         xmlns="http://www.w3.org/2000/svg"
                         height="24"
@@ -30,9 +19,7 @@
                         width="24"
                     >
                         <path d="M0 0h24v24H0V0z" fill="none" />
-                        <path
-                            d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
-                        />
+                        <path d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z" />
                     </svg>
                 </div>
             </button>
@@ -48,17 +35,29 @@
 </template>
 
 <script lang="ts">
-import { Vue, Prop } from 'vue-property-decorator';
+import { defineComponent } from 'vue';
 
-export default class HelpSectionV extends Vue {
-    @Prop() helpSection!: any;
+export default defineComponent({
+    name: 'HelpSectionV',
+    props: {
+        helpSection: {
+            type: Object,
+            required: true
+        }
+    },
 
-    expanded: boolean = false;
+    data() {
+        return {
+            expanded: false
+        };
+    },
 
-    toggleExpanded() {
-        this.expanded = !this.expanded;
+    methods: {
+        toggleExpanded() {
+            this.expanded = !this.expanded;
+        }
     }
-}
+});
 </script>
 
 <style lang="scss" scoped>

--- a/packages/ramp-core/src/fixtures/mapnav/buttons/fullscreen-nav.vue
+++ b/packages/ramp-core/src/fixtures/mapnav/buttons/fullscreen-nav.vue
@@ -27,7 +27,6 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { Vue } from 'vue-property-decorator';
 
 export default defineComponent({
     name: 'FullscreenNavV',

--- a/packages/ramp-core/src/fixtures/mapnav/buttons/home-nav.vue
+++ b/packages/ramp-core/src/fixtures/mapnav/buttons/home-nav.vue
@@ -10,7 +10,6 @@
 <script lang="ts">
 import { defineComponent } from 'vue';
 import { Extent } from '@/geo/api';
-import { Vue } from 'vue-property-decorator';
 
 export default defineComponent({
     name: 'HomeNavV',

--- a/packages/ramp-core/src/fixtures/mapnav/buttons/zoom-nav.vue
+++ b/packages/ramp-core/src/fixtures/mapnav/buttons/zoom-nav.vue
@@ -26,7 +26,6 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { Vue, Options } from 'vue-property-decorator';
 import { throttle } from 'throttle-debounce';
 import DividerNavV from './divider-nav.vue';
 

--- a/packages/ramp-core/src/fixtures/mapnav/mapnav.vue
+++ b/packages/ramp-core/src/fixtures/mapnav/mapnav.vue
@@ -18,7 +18,6 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { Vue, Options } from 'vue-property-decorator';
 import { get } from '@/store/pathify-helper';
 
 import ZoomNavV from './buttons/zoom-nav.vue';

--- a/packages/ramp-core/src/fixtures/northarrow/northarrow.vue
+++ b/packages/ramp-core/src/fixtures/northarrow/northarrow.vue
@@ -19,8 +19,6 @@ export default defineComponent({
         return {
             arrowIcon: get(NortharrowStore.arrowIcon),
             poleIcon: get(NortharrowStore.poleIcon),
-            // @Get(NortharrowStore.arrowIcon) arrowIcon!: string;
-            // @Get(NortharrowStore.poleIcon) poleIcon!: string;
             angle: 0,
             arrowLeft: 0,
             displayArrow: false,

--- a/packages/ramp-core/src/fixtures/overviewmap/overviewmap.vue
+++ b/packages/ramp-core/src/fixtures/overviewmap/overviewmap.vue
@@ -58,8 +58,6 @@ export default defineComponent({
         return {
             mapConfig: get(OverviewmapStore.mapConfig),
             startMinimized: get(OverviewmapStore.startMinimized),
-            // @Get(OverviewmapStore.mapConfig) mapConfig!: RampMapConfig,
-            // @Get(OverviewmapStore.startMinimized) startMinimized!: boolean,
 
             // TODO: find a way to fix this declaration (should be something like overviewMap: OverviewMapAPI but that gave a compile error)
             overviewMap: new OverviewMapAPI(this.$iApi),

--- a/packages/ramp-core/src/fixtures/settings/component.vue
+++ b/packages/ramp-core/src/fixtures/settings/component.vue
@@ -3,7 +3,7 @@
 </template>
 
 <script lang="ts">
-import { Vue, Prop } from 'vue-property-decorator';
+import { defineComponent } from 'vue';
 
 // Import control templates.
 import SliderControl from './templates/slider-control.vue';
@@ -12,20 +12,38 @@ import ToggleButtonControl from './templates/toggle-button-control.vue';
 import InputControl from './templates/input-control.vue';
 import { svgIcons } from './templates/icons';
 
-export default class SettingsComponentV extends Vue {
-    @Prop() type!: string;
-    @Prop() config!: any;
-    @Prop() name!: string;
-    @Prop() icon!: string;
+export default defineComponent({
+    name: 'SettingsComponentV',
+    props: {
+        type: {
+            type: String,
+            required: true
+        },
+        config: {
+            type: Object,
+            required: true
+        },
+        name: {
+            type: String,
+            required: true
+        },
+        icon: {
+            type: String,
+            required: true
+        }
+    },
 
-    icons: any = svgIcons;
-
-    // Binds each type to its respective Vue component.
-    templates = {
-        slider: SliderControl,
-        toggle: ToggleSwitchControl,
-        'toggle-button': ToggleButtonControl,
-        input: InputControl
-    };
-}
+    data() {
+        return {
+            icons: svgIcons,
+            // binds each type to its respective Vue component.
+            templates: {
+                slider: SliderControl,
+                toggle: ToggleSwitchControl,
+                'toggle-button': ToggleButtonControl,
+                input: InputControl
+            }
+        };
+    }
+});
 </script>

--- a/packages/ramp-core/src/fixtures/settings/templates/input-control.vue
+++ b/packages/ramp-core/src/fixtures/settings/templates/input-control.vue
@@ -19,14 +19,25 @@
 </template>
 
 <script lang="ts">
-import { Vue, Prop } from 'vue-property-decorator';
-import { Get, Sync, Call } from 'vuex-pathify';
+import { defineComponent } from 'vue';
 
-export default class SliderControl extends Vue {
-    @Prop() config!: any;
-    @Prop() name!: string;
-    @Prop() icon!: string;
-}
+export default defineComponent({
+    name: 'SliderControl',
+    props: {
+        config: {
+            type: Object,
+            required: true
+        },
+        name: {
+            type: String,
+            required: true
+        },
+        icon: {
+            type: String,
+            required: true
+        }
+    }
+});
 </script>
 
 <style lang="scss" scoped>

--- a/packages/ramp-core/src/fixtures/settings/templates/toggle-button-control.vue
+++ b/packages/ramp-core/src/fixtures/settings/templates/toggle-button-control.vue
@@ -13,15 +13,26 @@
 </template>
 
 <script lang="ts">
-import { Vue, Prop } from 'vue-property-decorator';
-import { Get, Sync, Call } from 'vuex-pathify';
+import { defineComponent } from 'vue';
 import Toggle from '@vueform/toggle';
 
-export default class ToggleButtonControl extends Vue {
-    @Prop() config: any;
-    @Prop() name!: string;
-    @Prop() icon!: string;
-}
+export default defineComponent({
+    name: 'ToggleButtonControl',
+    props: {
+        config: {
+            type: Object,
+            required: true
+        },
+        name: {
+            type: String,
+            required: true
+        },
+        icon: {
+            type: String,
+            required: true
+        }
+    }
+});
 </script>
 
 <style lang="scss" scoped>

--- a/packages/ramp-core/src/fixtures/settings/templates/toggle-switch-control.vue
+++ b/packages/ramp-core/src/fixtures/settings/templates/toggle-switch-control.vue
@@ -31,7 +31,6 @@
 
 <script lang="ts">
 import { defineComponent, watch } from 'vue';
-import { Vue, Prop } from 'vue-property-decorator';
 
 export default defineComponent({
     name: 'ToggleSwitchControl',

--- a/packages/ramp-core/src/fixtures/wizard/stepper-item.vue
+++ b/packages/ramp-core/src/fixtures/wizard/stepper-item.vue
@@ -52,6 +52,7 @@
 
 <script lang="ts">
 import { Vue, Prop, Inject } from 'vue-property-decorator';
+// import { defineComponent, inject } from 'vue';
 
 export default class WizardStepperItemV extends Vue {
     @Prop() title!: string;
@@ -73,6 +74,40 @@ export default class WizardStepperItemV extends Vue {
         return this.stepper.activeIndex === this.index;
     }
 }
+// export default defineComponent({
+//     name: 'WizardStepperItemV',
+//     props: {
+//         title: {
+//             type: String,
+//             required: true
+//         },
+//         summary: {
+//             type: String,
+//             required: true
+//         }
+//     },
+//     inject: ['stepper'],
+
+//     data() {
+//         return {
+//             index: -1
+//         };
+//     },
+
+//     mounted() {
+//         this.index = this.stepper.numSteps++;
+//     },
+
+//     methods: {
+//         done() {
+//             return this.stepper.activeIndex > this.index;
+//         },
+
+//         active() {
+//             return this.stepper.activeIndex === this.index;
+//         }
+//     }
+// });
 </script>
 
 <style lang="scss" scoped>

--- a/packages/ramp-core/src/fixtures/wizard/stepper.vue
+++ b/packages/ramp-core/src/fixtures/wizard/stepper.vue
@@ -6,6 +6,7 @@
 
 <script lang="ts">
 import { Vue, Watch, Prop, Provide } from 'vue-property-decorator';
+// import { defineComponent } from 'vue';
 
 export default class WizardStepperV extends Vue {
     @Prop({ default: 0 }) activeStep!: number;
@@ -16,6 +17,30 @@ export default class WizardStepperV extends Vue {
         this.stepper.activeIndex = this.activeStep;
     }
 }
+// export default defineComponent({
+//     name: 'WizardStepperV',
+//     props: {
+//         activeStep: {
+//             type: Number,
+//             default: 0
+//         }
+//     },
+
+//     provide() {
+//         return {
+//             stepper: {
+//                 activeIndex: this.activeStep,
+//                 numSteps: 0
+//             }
+//         };
+//     },
+
+//     watch: {
+//         activeStep() {
+//             this.stepper.activeIndex = this.activeStep;
+//         }
+//     }
+// });
 </script>
 
 <style lang="scss" scoped></style>


### PR DESCRIPTION
[Demo](http://ramp4-app.azureedge.net/demo/users/yileifeng/vue3-define-component/host/index.html#)

**Changes**:
- rewrite almost all the remaining components with `defineComponent` structure
- cleaned up some `vuex-pathify` and `vue-property-decorator` imports

**Concerns**:
- didn't rewrite the `iklob` component since it might cause merge conflicts
- didn't convert wizard `stepper` and `stepper-item` due to TS errors regarding provide/inject that I couldn't find a good way to solve (a conversion to using composition API's `setup()` might be the best solution)
- a bit worried in general that team will prefer the class syntax from `vue-property-decorator`, but then again I have not seen any docs that specify that `vue-class-component` will support composition API or such for Vue 3

**Testing**:
Everything should still be functional :pray: