### PR TITLE
Migrate iklob fixture (partial)

### DIFF
--- a/packages/ramp-core/public/index-e2e.html
+++ b/packages/ramp-core/public/index-e2e.html
@@ -15,11 +15,12 @@
         <script src="../sample-fixtures/mouruge-fixture.js"></script>
         <script src="../sample-fixtures/diligord-fixture.js"></script>
 
+        <!-- this fixture will load after Vue is loaded; `iklob` requires Vue to be exposed on the global scope -->
+        <script src="../sample-fixtures/iklob-fixture.js"></script>
+
         <!-- RAMP will be injected here -->
     </head>
     <body style="margin: 0;">
-        <!-- this fixture will load after RAMP (and Vue) are loaded (since Vue is bundled with RAMP in `dev`); `iklob` requires Vue to be exposed on the global scope -->
-        <script src="../sample-fixtures/iklob-fixture.js"></script>
 
         <div id="app"></div>
 

--- a/packages/ramp-core/public/starter-scripts/panel-party.js
+++ b/packages/ramp-core/public/starter-scripts/panel-party.js
@@ -764,13 +764,12 @@ let options = {
 
 rInstance = new RAMP.Instance(document.getElementById('app'), config, options);
 
-// TODO: fix console errors
-// var iklobLoad = rInstance.event.on('fixture/added', fixture => {
-//     if (fixture.id === 'iklob') {
-//         rInstance.event.off(iklobLoad);
-//         rInstance.panel.open('iklob-p1');
-//     }
-// });
+var iklobLoad = rInstance.event.on('fixture/added', fixture => {
+    if (fixture.id === 'iklob') {
+        rInstance.event.off(iklobLoad);
+        rInstance.panel.open('iklob-p1');
+    }
+});
 
 rInstance.fixture.addDefaultFixtures().then(() => {
     rInstance.panel.open('geosearch-panel');

--- a/packages/ramp-core/src/components/panel-stack/panel-screen.vue
+++ b/packages/ramp-core/src/components/panel-stack/panel-screen.vue
@@ -28,8 +28,8 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, PropType } from 'vue';
 import { PanelInstance } from '@/api';
+import { defineComponent, PropType } from 'vue';
 
 export default defineComponent({
     name: 'PanelScreenV',

--- a/packages/ramp-core/src/main.ts
+++ b/packages/ramp-core/src/main.ts
@@ -5,7 +5,8 @@
 // so we need to expose RAMP API on the window manually
 import api from '@/api';
 //@ts-ignore
-import Vue from 'vue/dist/vue.esm-bundler.js';
+// import Vue from 'vue/dist/vue.esm-bundler.js';
+import Vue from 'vue/dist/vue.global.js';
 import '@/styles/main.css';
 
 // assign RAMP api to global variable

--- a/packages/ramp-sample-fixtures/src/iklob/main.ts
+++ b/packages/ramp-sample-fixtures/src/iklob/main.ts
@@ -1,14 +1,16 @@
 import screen from './screen.vue';
-
 class IklobFixture {
     added(): void {
         // TODO: import `FixtureInstance` types
-        (this as any).$iApi.panel.register({
-            id: 'iklob-p1',
-            config: {
-                screens: { 'iklob-s1': screen }
-            }
-        });
+        (this as any).$iApi.panel.register(
+            {
+                id: 'iklob-p1',
+                config: {
+                    screens: { 'iklob-s1': screen }
+                }
+            },
+            {}
+        );
     }
 }
 
@@ -24,8 +26,6 @@ const handle = setInterval(() => {
     if (!rInstance) {
         return;
     }
-
     rInstance.fixture.add('iklob', IklobFixture);
-
     clearInterval(handle);
-}, 1000);
+}, 5000);

--- a/packages/ramp-sample-fixtures/src/iklob/screen.vue
+++ b/packages/ramp-sample-fixtures/src/iklob/screen.vue
@@ -1,5 +1,5 @@
 <template>
-    <panel-screen>
+    <panel-screen :panel="panel">
         <template #header>
             Iklob Fixture
         </template>
@@ -17,14 +17,14 @@
 </template>
 
 <script lang="ts">
-// use Vue decorators for a more complex example
-// this will results in a somewhat larger bundles since Vue decorators will be included in the bundle
+import { defineComponent } from 'vue';
 
-import { Vue, Prop } from 'vue-property-decorator';
-
-export default class IklobFixtureV extends Vue {
-    @Prop() panel!: any; /* PanelInstance ;*/ // TODO: import `PanelInstance` type
-}
+export default defineComponent({
+    name: 'IklobFixtureV',
+    props: {
+        panel: Object
+    }
+});
 </script>
 
 <style scoped></style>


### PR DESCRIPTION
## Fixes in this PR
- [FIX] Iklob fixture now displays properly **\*\*(in prod build)\*\***
- [FIX] Refactored iklob screen to use `defineComponent`

## Further work/comments/questions
- **Further Work:**
    - DiliRugeLob panels are blank in dev build

## Steps to test
[Demo](http://ramp4-app.azureedge.net/demo/users/sharvenp/vue3-iklob-fixture/host/index-e2e.html?script=panel-party)

1. Load Demo
2. The iklob panel should display properly