### PR TITLE
Fix `markRaw` warnings

### DIFF
--- a/packages/ramp-core/src/api/notifications.ts
+++ b/packages/ramp-core/src/api/notifications.ts
@@ -1,3 +1,4 @@
+import { markRaw } from 'vue';
 import { APIScope, InstanceAPI } from './internal';
 
 import NotificationsScreenV from '@/components/notification-center/screen.vue';
@@ -20,7 +21,7 @@ export class NotificationAPI extends APIScope {
         this.$iApi.panel.register({
             id: 'notifications-panel',
             config: {
-                screens: { 'notifications-screen': NotificationsScreenV }
+                screens: { 'notifications-screen': markRaw(NotificationsScreenV) }
             }
         });
     }
@@ -49,9 +50,7 @@ export class NotificationAPI extends APIScope {
      */
     addGroup(id: string, type: NotificationType, message: string) {
         if (this.getGroup(id)) {
-            throw new Error(
-                'Duplicate notification group id registration: ' + id
-            );
+            throw new Error('Duplicate notification group id registration: ' + id);
         }
         const group = new NotificationGroup(this.$iApi, id, type, message);
 
@@ -90,12 +89,7 @@ export class NotificationGroup extends APIScope {
      * @param type The type of notification the group will show
      * @param message The main message for the group
      */
-    constructor(
-        $iApi: InstanceAPI,
-        id: string,
-        type: NotificationType,
-        message: string
-    ) {
+    constructor($iApi: InstanceAPI, id: string, type: NotificationType, message: string) {
         super($iApi);
 
         this.id = id;

--- a/packages/ramp-core/src/fixtures/basemap/index.ts
+++ b/packages/ramp-core/src/fixtures/basemap/index.ts
@@ -1,3 +1,4 @@
+import { markRaw } from 'vue';
 import BasemapScreenV from './screen.vue';
 import { BasemapAPI } from './api/basemap';
 import { basemap } from './store/index';
@@ -24,7 +25,7 @@ class BasemapFixture extends BasemapAPI {
             {
                 id: 'basemap-panel',
                 config: {
-                    screens: { 'basemap-component': BasemapScreenV }
+                    screens: { 'basemap-component': markRaw(BasemapScreenV) }
                 }
             },
             { i18n: { messages } }

--- a/packages/ramp-core/src/fixtures/export-v1/index.ts
+++ b/packages/ramp-core/src/fixtures/export-v1/index.ts
@@ -1,5 +1,5 @@
+import { markRaw } from 'vue';
 import { ExportV1API } from './api';
-
 import ExportV1AppbarButtonV from './appbar-button.vue';
 import ExportV1ScreenV from './screen.vue';
 
@@ -22,7 +22,7 @@ class ExportV1Fixture extends ExportV1API {
             {
                 id: 'export-v1-panel',
                 config: {
-                    screens: { 'export-v1-screen': ExportV1ScreenV },
+                    screens: { 'export-v1-screen': markRaw(ExportV1ScreenV) },
                     style: {
                         'flex-grow': '1',
                         'max-width': '800px'

--- a/packages/ramp-core/src/fixtures/gazebo/index.ts
+++ b/packages/ramp-core/src/fixtures/gazebo/index.ts
@@ -1,3 +1,4 @@
+import { markRaw } from 'vue';
 import { FixtureInstance } from '@/api';
 import { AsyncComponentEh } from '@/store/modules/panel';
 
@@ -37,8 +38,8 @@ class GazeboFixture extends FixtureInstance {
                 id: 'p1',
                 config: {
                     screens: {
-                        'p-1-screen-1': GazeboP1Screen1V,
-                        'p-1-screen-2': GazeboP1Screen2V
+                        'p-1-screen-1': markRaw(GazeboP1Screen1V),
+                        'p-1-screen-2': markRaw(GazeboP1Screen2V)
                     },
                     style: {
                         'flex-grow': '1',
@@ -70,11 +71,11 @@ class GazeboFixture extends FixtureInstance {
                             return new Promise<AsyncComponentEh>(resolve =>
                                 setTimeout(
                                     () =>
-                                        import(/* webpackChunkName: "p-2-screen-1" */ `./p2-screen-1.vue`).then(
-                                            data => {
-                                                resolve(data);
-                                            }
-                                        ),
+                                        import(
+                                            /* webpackChunkName: "p-2-screen-1" */ `./p2-screen-1.vue`
+                                        ).then(data => {
+                                            resolve(data);
+                                        }),
                                     2000
                                 )
                             );
@@ -91,7 +92,9 @@ class GazeboFixture extends FixtureInstance {
                          * returning a `VueConstructor` in a promise
                          */
                         'p-2-screen-3': () => {
-                            return new Promise<AsyncComponentEh>(resolve => resolve(GazeboP2Screen3V));
+                            return new Promise<AsyncComponentEh>(resolve =>
+                                resolve(markRaw(GazeboP2Screen3V))
+                            );
                         }
                     },
                     style: {

--- a/packages/ramp-core/src/fixtures/geosearch/index.ts
+++ b/packages/ramp-core/src/fixtures/geosearch/index.ts
@@ -1,3 +1,4 @@
+import { markRaw } from 'vue';
 import GeosearchScreenV from './screen.vue';
 import { GeosearchAPI } from './api/geosearch';
 import { geosearch } from './store/index';
@@ -18,7 +19,7 @@ class GeosearchFixture extends GeosearchAPI {
             {
                 id: 'geosearch-panel',
                 config: {
-                    screens: { 'geosearch-component': GeosearchScreenV }
+                    screens: { 'geosearch-component': markRaw(GeosearchScreenV) }
                 }
             },
             { i18n: { messages } }

--- a/packages/ramp-core/src/fixtures/help/index.ts
+++ b/packages/ramp-core/src/fixtures/help/index.ts
@@ -1,3 +1,4 @@
+import { markRaw } from 'vue';
 import { HelpAPI } from './api/help';
 import { help } from './store/index';
 import HelpScreenV from './screen.vue';
@@ -17,7 +18,7 @@ class HelpFixture extends HelpAPI {
             {
                 'help-panel': {
                     screens: {
-                        'help-screen': HelpScreenV
+                        'help-screen': markRaw(HelpScreenV)
                     },
                     style: {
                         'flex-grow': '1',

--- a/packages/ramp-core/src/fixtures/legend/components/component.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/component.vue
@@ -13,7 +13,7 @@ import LayerEntryV from './entry.vue';
 import LegendGroupV from './group.vue';
 import LegendVisibilitySetV from './visibility-set.vue';
 import LegendPlaceholderV from './placeholder.vue';
-import { defineComponent, PropType } from 'vue';
+import { defineComponent, PropType, markRaw } from 'vue';
 import { LegendItem, LegendTypes } from '../store/legend-defs';
 
 export default defineComponent({
@@ -25,10 +25,10 @@ export default defineComponent({
     methods: {
         getCurrentTemplate(): string {
             const templates: any = {
-                [LegendTypes.Set]: LegendVisibilitySetV,
-                [LegendTypes.Group]: LegendGroupV,
-                [LegendTypes.Entry]: LayerEntryV,
-                [LegendTypes.Placeholder]: LegendPlaceholderV
+                [LegendTypes.Set]: markRaw(LegendVisibilitySetV),
+                [LegendTypes.Group]: markRaw(LegendGroupV),
+                [LegendTypes.Entry]: markRaw(LayerEntryV),
+                [LegendTypes.Placeholder]: markRaw(LegendPlaceholderV)
             };
             return templates[this.legendItem.type];
         }

--- a/packages/ramp-core/src/fixtures/legend/index.ts
+++ b/packages/ramp-core/src/fixtures/legend/index.ts
@@ -1,8 +1,8 @@
+import { markRaw } from 'vue';
 import { LegendAPI } from './api/legend';
-import { LegendStore, legend } from './store/index';
+import { legend } from './store/index';
 import LegendScreenV from './screen.vue';
 import LegendAppbarButtonV from './appbar-button.vue';
-import { GlobalEvents, LayerInstance } from '@/api';
 
 import messages from './lang/lang.csv';
 
@@ -13,7 +13,7 @@ class LegendFixture extends LegendAPI {
             {
                 'legend-panel': {
                     screens: {
-                        'legend-screen': LegendScreenV
+                        'legend-screen': markRaw(LegendScreenV)
                     },
                     style: {
                         width: '350px'

--- a/packages/ramp-core/src/fixtures/metadata/index.ts
+++ b/packages/ramp-core/src/fixtures/metadata/index.ts
@@ -1,3 +1,4 @@
+import { markRaw } from 'vue';
 import { MetadataAPI } from './api/metadata';
 import MetadataAppbarButtonV from './appbar-button.vue';
 
@@ -11,7 +12,7 @@ class MetadataFixture extends MetadataAPI {
             {
                 'metadata-panel': {
                     screens: {
-                        'metadata-screen-content': MetadataScreenV
+                        'metadata-screen-content': markRaw(MetadataScreenV)
                     },
                     style: {
                         width: '350px'
@@ -22,19 +23,13 @@ class MetadataFixture extends MetadataAPI {
         );
 
         let handler = (payload: any) => {
-            const metadataFixture: MetadataAPI = this.$iApi.fixture.get(
-                'metadata'
-            );
+            const metadataFixture: MetadataAPI = this.$iApi.fixture.get('metadata');
             metadataFixture.openMetadata(payload);
         };
 
         this.$iApi.component('metadata-appbar-button', MetadataAppbarButtonV);
 
-        this.$iApi.event.on(
-            'metadata/open',
-            handler,
-            'metadata_opened_handler'
-        );
+        this.$iApi.event.on('metadata/open', handler, 'metadata_opened_handler');
     }
 }
 

--- a/packages/ramp-core/src/fixtures/settings/component.vue
+++ b/packages/ramp-core/src/fixtures/settings/component.vue
@@ -3,7 +3,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue';
+import { defineComponent, markRaw } from 'vue';
 
 // Import control templates.
 import SliderControl from './templates/slider-control.vue';
@@ -38,10 +38,10 @@ export default defineComponent({
             icons: svgIcons,
             // binds each type to its respective Vue component.
             templates: {
-                slider: SliderControl,
-                toggle: ToggleSwitchControl,
-                'toggle-button': ToggleButtonControl,
-                input: InputControl
+                slider: markRaw(SliderControl),
+                toggle: markRaw(ToggleSwitchControl),
+                'toggle-button': markRaw(ToggleButtonControl),
+                input: markRaw(InputControl)
             }
         };
     }

--- a/packages/ramp-core/src/fixtures/settings/index.ts
+++ b/packages/ramp-core/src/fixtures/settings/index.ts
@@ -1,3 +1,4 @@
+import { markRaw } from 'vue';
 import { SettingsAPI } from './api/settings';
 import SettingsAppbarButtonV from './appbar-button.vue';
 
@@ -11,7 +12,7 @@ class SettingsFixture extends SettingsAPI {
             {
                 'settings-panel': {
                     screens: {
-                        'settings-screen-content': SettingsScreenV
+                        'settings-screen-content': markRaw(SettingsScreenV)
                     },
                     style: {
                         width: '350px'

--- a/packages/ramp-core/src/fixtures/wizard/index.ts
+++ b/packages/ramp-core/src/fixtures/wizard/index.ts
@@ -1,3 +1,4 @@
+import { markRaw } from 'vue';
 import { WizardAPI } from './api/wizard';
 import WizardScreenV from './screen.vue';
 import { wizard } from './store/index';
@@ -12,7 +13,7 @@ class WizardFixture extends WizardAPI {
             {
                 'wizard-panel': {
                     screens: {
-                        'wizard-screen': WizardScreenV
+                        'wizard-screen': markRaw(WizardScreenV)
                     },
                     style: {
                         width: '350px'

--- a/packages/ramp-sample-fixtures/src/iklob/main.ts
+++ b/packages/ramp-sample-fixtures/src/iklob/main.ts
@@ -1,3 +1,4 @@
+import { markRaw } from 'vue';
 import screen from './screen.vue';
 class IklobFixture {
     added(): void {
@@ -6,7 +7,7 @@ class IklobFixture {
             {
                 id: 'iklob-p1',
                 config: {
-                    screens: { 'iklob-s1': screen }
+                    screens: { 'iklob-s1': markRaw(screen) }
                 }
             },
             {}


### PR DESCRIPTION
## Fixes in this PR
- [FIX] Fixed Vue warnings that suggest to use `markRaw` to avoid overhead

## Steps to test
[Demo](http://ramp4-app.azureedge.net/demo/users/sharvenp/vue3-mark-raw/host/index.html)
[Demo - Panel Party](http://ramp4-app.azureedge.net/demo/users/sharvenp/vue3-mark-raw/host/index-e2e.html?script=panel-party)

1. Load Demo
2. Open the console and check for any "`markRaw`" warnings
3. Ensure the app and panels still work (no real way to test this, just try to break it)
    - Test reactivity of panels as well