### PR TITLE
Load diligord and mouruge

### DIFF
--- a/packages/ramp-core/host/index-e2e.html
+++ b/packages/ramp-core/host/index-e2e.html
@@ -10,12 +10,12 @@
 
         <link rel="stylesheet" href="./../dist/RAMP.css" />
 
+        <!-- the host page must load Vue since RAMP doesn't bundle it -->
+        <script src="https://unpkg.com/vue@3.1.5/dist/vue.global.js"></script>
+
         <!-- these two fixtures will load before either RAMP is loaded -->
         <script src="./../dist/sample-fixtures/mouruge-fixture.js"></script>
         <script src="./../dist/sample-fixtures/diligord-fixture.js"></script>
-
-        <!-- the host page must load Vue since RAMP doesn't bundle it -->
-        <script src="https://unpkg.com/vue@3.1.5/dist/vue.global.js"></script>
 
         <!-- this fixture will load after Vue is loaded; `iklob` requires Vue to be exposed on the global scope -->
         <script src="./../dist/sample-fixtures/iklob-fixture.js"></script>
@@ -33,8 +33,7 @@
             let starterParam = params.get('script');
             if (starterParam) {
                 // html-webpack-plugin doesn't like template strings
-                script.src =
-                    './../dist/starter-scripts/' + starterParam + '.js';
+                script.src = './../dist/starter-scripts/' + starterParam + '.js';
             } else {
                 script.src = './../dist/ramp-starter.js';
             }

--- a/packages/ramp-core/public/starter-scripts/panel-party.js
+++ b/packages/ramp-core/public/starter-scripts/panel-party.js
@@ -868,12 +868,12 @@ rInstance.fixture.add('gazebo').then(() => {
         .open({ screen: 'p-2-screen-2' })
         .pin();
 });
-// rInstance.fixture.add('diligord', window.hostFixtures.diligord).then(() => {
-//     rInstance.panel.open('diligord-p1');
-// });
-// rInstance.fixture.add('mouruge', window.hostFixtures.mouruge).then(() => {
-//     rInstance.panel.open('mouruge-p1');
-// });
+rInstance.fixture.add('diligord', window.hostFixtures.diligord).then(() => {
+    rInstance.panel.open('diligord-p1');
+});
+rInstance.fixture.add('mouruge', window.hostFixtures.mouruge).then(() => {
+    rInstance.panel.open('mouruge-p1');
+});
 
 // add export-v1 fixtures
 rInstance.fixture.add('export-v1');

--- a/packages/ramp-core/src/api/fixture.ts
+++ b/packages/ramp-core/src/api/fixture.ts
@@ -1,11 +1,4 @@
-import Vue, {
-    Component,
-    ComponentOptions,
-    createApp,
-    defineComponent,
-    createVNode,
-    render
-} from 'vue';
+import Vue, { Component, ComponentOptions, createApp, defineComponent, h, render } from 'vue';
 
 import { APIScope, GlobalEvents, InstanceAPI } from './internal';
 import { FixtureBase, FixtureMutation, FixtureBaseSet } from '@/store/modules/fixture';
@@ -219,7 +212,8 @@ export class FixtureInstance extends APIScope implements FixtureBase {
                 get(): any {
                     return instance.config;
                 }
-            }
+            },
+            mount: { value: instance.mount }
         });
 
         return value as FixtureInstance;
@@ -301,7 +295,7 @@ export class FixtureInstance extends APIScope implements FixtureBase {
     mount(component: Component, { props, children, element, app }: any = {}) {
         let el = element;
 
-        let vNode: any = createVNode(component, props, children);
+        let vNode: any = h(component, props, children);
         if (app && app._context) {
             vNode.appContext = app._context;
         }

--- a/packages/ramp-core/src/fixtures/metadata/index.ts
+++ b/packages/ramp-core/src/fixtures/metadata/index.ts
@@ -1,7 +1,6 @@
 import { markRaw } from 'vue';
 import { MetadataAPI } from './api/metadata';
 import MetadataAppbarButtonV from './appbar-button.vue';
-
 import MetadataScreenV from './screen.vue';
 
 import messages from './lang/lang.csv';

--- a/packages/ramp-sample-fixtures/src/diligord/diligord-fixture.js
+++ b/packages/ramp-sample-fixtures/src/diligord/diligord-fixture.js
@@ -1,7 +1,7 @@
 // this is a plain JS sample fixture that doesn't require a compilation step since it doesn't use Vue templates
 // instead, templates need to be written as a render function directly
 // consequently, this makes for a smallest fixture bundle
-import { h } from 'vue';
+import { h, markRaw, resolveComponent } from 'vue';
 
 (function() {
     const messages = {
@@ -27,12 +27,11 @@ import { h } from 'vue';
         i18n: {
             messages
         },
-
         // these are regular Vue component methods that can be called from the template directly
         // this component will have access to the API instance (`this.$iApi`) of the R4MP Vue app it runs inside
         methods: {
             // this can't be an arrow function since it won't have access to `this`
-            closeMethod: function() {
+            closeMethod() {
                 this.panel.close();
             }
         },
@@ -41,7 +40,7 @@ import { h } from 'vue';
         computed: {
             // this returns `true` if the current panel is pinned by comparing the id of the pinned panel with the id of this panel
             // this is used to modify the icon inside the `pin` header control
-            isPinned: function() {
+            isPinned() {
                 return this.$iApi.panel.pinned && this.$iApi.panel.pinned.id === this.panel.id;
 
                 // or just
@@ -50,78 +49,88 @@ import { h } from 'vue';
         },
 
         // reactive component data
-        data: function() {
+        data() {
             return {
                 title: 'Diligord Panel',
                 count: 0
             };
         },
+        // NOTE: revisit this render() function later...
+        // This is currently not completely functional. In particular, I can't seem to get named slots to work (see below for details).
+        // In dev, none of the ramp components (panel-screen, pin, close) render, but the normal HTML elements do. So we get a panel that has all the intended contents,
+        // but without the proper panel layout. This is probably related to the blank panel issue that mouruge and iklob have as well.
+        // In prod, nothing inside of a named slot renders. So we get a panel with the proper panel layout, but none of the intended contents.
         render() {
             // using built-in `pin` panel header control; can use either `this.isPinned` getter method or the `this.panel.isPinned` panel getter
             const pin =
                 this.$iApi.screenSize === 'xs'
                     ? undefined
-                    : h('pin', { props: { active: this.isPinned }, on: { click: () => this.panel.pin(!this.panel.isPinned) } });
+                    : h(resolveComponent('pin'), {
+                          props: { active: this.isPinned },
+                          onClick: () => this.panel.pin(!this.panel.isPinned)
+                      });
 
             const close =
                 this.$iApi.screenSize === 'xs'
                     ? undefined
-                    : h('close', {
-                          on: {
-                              click: () => this.panel.close() // this works ✔
-                              // click: this.closeMethod, // this also works ✔
-                              // click: this.panel.close // this doesn't work ❌
-                          }
+                    : h(resolveComponent('close'), {
+                          onClick: () => this.panel.close() // this works ✔
+                          // onClick: this.closeMethod, // this also works ✔
+                          // onClick: this.panel.close // this doesn't work ❌
                       });
 
-            return h('panel-screen', { props: { panel: this.panel } }, [
-                // pass a `span` to the `header` slot of the panel-screen
-                h('template', { slot: 'header' }, [h('span', this.title)]),
+            const panelScreen = resolveComponent('panel-screen');
+            return h(
+                panelScreen,
+                {
+                    props: { panel: this.panel }
+                },
+                [
+                    // NOTE: The following comments are relevent to the panel in prod. See above for differences between the dev and prod builds.
+                    // This method for slots is ported from vue2 r4mp. It's mentioned in the vue2 docs, but not the vue3 docs.
+                    // This works with unnamed slots, but doesn't seem to work with named slots.
+                    h('span', { slot: 'header' }, this.title),
 
-                // pass `pin` and `close` controls `controls` slot of the panel-screen
-                h('template', { slot: 'controls' }, [pin, close]),
+                    // The following methods have also been tried (this is what the vue3 docs say to use).
+                    // Only the first option here worked with unnamed slots. Neither named nor unnamed worked for the second.
+                    // h('span', {}, { header: () => this.title }),
+                    // h('span', {}, { header: () => h('p', {}, this.title)}),
 
-                // pass screen content to the `header` slot of the panel-screen
-                h('template', { slot: 'content' }, [
-                    h('div', { class: 'flex flex-col items-center justify-center' }, [
+                    // This puts pin and close in a span, parent element's flex doesn't work on them individually because of this
+                    // Consider using 'template' as the parent element when trying to fix.
+                    h('span', { slot: 'controls' }, [pin, close]),
+
+                    h('div', { slot: 'content', class: 'flex flex-col items-center justify-center' }, [
                         h(
                             'button',
                             {
                                 class: 'bg-purple-500 hover:bg-purple-700 text-white font-bold py-8 px-16',
-                                on: { click: () => (this.count += 10) }
+                                onClick: () => (this.count += 10)
                             },
                             [h('span', this.count)]
                         ),
                         h('label', { class: 'mt-16' }, this.$t('changeTitle')),
-
                         h('input', {
                             class: 'border-2  p-8',
-
                             // bind title to the input value
-                            domProps: {
-                                value: this.title
-                            },
-                            on: {
-                                input: () => {
-                                    this.title = event.target.value;
-                                }
+                            value: this.title,
+                            onInput: $event => {
+                                this.title = $event.target.value;
                             }
                         }),
-
+                        // A gif will show if the title is changed to "fight"
                         this.title === 'fight'
                             ? h('img', {
                                   style: {
                                       width: '300px',
                                       marginTop: '30px'
                                   },
-                                  domProps: {
-                                      src: 'https://media.giphy.com/media/sGAlRSaXKjTfq/giphy.gif'
-                                  }
+                                  src: 'https://media.giphy.com/media/sGAlRSaXKjTfq/giphy.gif'
                               })
                             : null
                     ])
-                ])
-            ]);
+                ]
+            );
         }
     };
 
@@ -129,7 +138,7 @@ import { h } from 'vue';
     const dpanel = {
         id: 'diligord-p1',
         config: {
-            screens: { 'diligord-s1': dScreen1 }
+            screens: { 'diligord-s1': markRaw(dScreen1) }
         }
     };
 
@@ -137,12 +146,14 @@ import { h } from 'vue';
     class DiligordFixture {
         added() {
             // `this.id` and `this.$iApi` and `this.$vApp` are automatically made available on this object
-            console.log(this.id, this.$iApi, this.$vApp);
+            this.id;
+            this.$iApi;
+            this.$vApp;
 
             // you can also create a custom component using the helper `extend` function and put it anywhere on the page, even outside the R4MP container
             // the helper function will add references to this fixture and `$iApi` to the extended component
             const component = this.extend({
-                render: function(h) {
+                render() {
                     return h(
                         'p',
                         {
@@ -157,7 +168,7 @@ import { h } from 'vue';
                         [this.firstName, ' ', this.lastName, ' aka ', this.alias]
                     );
                 },
-                data: function() {
+                data() {
                     return {
                         firstName: 'Walter',
                         lastName: 'White',
@@ -167,7 +178,7 @@ import { h } from 'vue';
             });
 
             // and put it on the page
-            document.querySelector('.ramp-app').after(component.$el);
+            document.querySelector('.ramp-app').after(component);
 
             // this life hook is called when the fixture is added to R4MP, and now it's possible to open our panel
             this.$iApi.panel.register(dpanel);


### PR DESCRIPTION
### Changes
- Diligord and Mouruge panels open

### Issues
- Mouruge template loads in prod but not on dev. Should be the same issue as Iklob
- Diligord has the same issue but made slightly more convoluted by the use of the `render()` function. 
    - In dev, none of the ramp components (`panel-screen`, `pin`, `close`) render, but the normal HTML elements do.
![2021-09-16 16_17_01-Panel Party](https://user-images.githubusercontent.com/33560973/133815613-c6f28146-57c8-41bb-bd2e-c5edf224f55f.png)
    - In prod, the ramp components render, but anything inside a `<slot>` does not.
![2021-09-16 16_32_46-Panel Party](https://user-images.githubusercontent.com/33560973/133815631-84418a9d-bebf-4e73-94c7-ad806ca6e9bd.png)
    - See code comments for more details.

Demo - [panel-party](http://ramp4-app.azureedge.net/demo/users/elsa-huang/vue3-panel-party/host/index-e2e.html?script=panel-party)