### PR TITLE
Fix opacity bar desync when layer reloads

### DIFF
--- a/packages/ramp-core/src/fixtures/settings/screen.vue
+++ b/packages/ramp-core/src/fixtures/settings/screen.vue
@@ -139,14 +139,18 @@ export default defineComponent({
 
         this.handlers.push(
             this.$iApi.event.on(GlobalEvents.LAYER_RELOAD_END, (reloadedLayer: LayerInstance) => {
-                if (reloadedLayer.layerType === LayerType.MAPIMAGE) {
-                    // Check if this.uid is a child of reloadedLayer
-                    if (reloadedLayer.getLayerTree().findChildByUid(this.uid)) {
-                        this.visibilityModel = true;
+                reloadedLayer.isLayerLoaded().then(() => {
+                    if (reloadedLayer.layerType === LayerType.MAPIMAGE) {
+                        // Check if this.uid is a child of reloadedLayer
+                        if (reloadedLayer.getLayerTree().findChildByUid(this.uid)) {
+                            this.visibilityModel = this.layer.getVisibility(this.uid);
+                            this.opacityModel = this.layer.getOpacity(this.uid) * 100;
+                        }
+                    } else if (this.uid === reloadedLayer.uid) {
+                        this.visibilityModel = this.layer.getVisibility(this.uid);
+                        this.opacityModel = this.layer.getOpacity(this.uid) * 100;
                     }
-                } else if (this.uid === reloadedLayer.uid) {
-                    this.visibilityModel = true;
-                }
+                });
             })
         );
     },

--- a/packages/ramp-core/src/fixtures/settings/templates/slider-control.vue
+++ b/packages/ramp-core/src/fixtures/settings/templates/slider-control.vue
@@ -31,6 +31,15 @@ export default defineComponent({
         icon: String,
         config: Object
     },
+    watch: {
+        // watch the config for changes to the opacity value
+        config: {
+            handler(newConfig) {
+                this.value = newConfig.value;
+            },
+            deep: true
+        }
+    },
     data() {
         return {
             value: this.config?.value


### PR DESCRIPTION
**Note:** This is a bug with RAMP and is not caused by the Vue3 migration. I am pushing the fix in Vue3 to avoid having to migrate the fix later since the fix uses the Vue3 `watch` API. 

## Fixes in this PR
- [FIX] The opacity bar in the settings panel will reset the opacity value to the start value (specified in the config) when the layer reloads

## Steps to test
[Demo](http://ramp4-app.azureedge.net/demo/users/sharvenp/vue3-opacity-bar/host/index.html)

1. Load Demo
2. Open a layer' settings
3. Set the layer opacity to some value
4. Reload the layer - the opacity value should now be set to the starting opacity of the layer