### PR TITLE
fix minimize button component and overview map

### DIFF
--- a/packages/ramp-core/src/api/instance.ts
+++ b/packages/ramp-core/src/api/instance.ts
@@ -24,9 +24,9 @@ import PanelScreenV from '@/components/panel-stack/panel-screen.vue';
 import PinV from '@/components/panel-stack/controls/pin.vue';
 import CloseV from '@/components/panel-stack/controls/close.vue';
 import BackV from '@/components/panel-stack/controls/back.vue';
+import MinimizeV from '@/components/panel-stack/controls/minimize.vue';
 import PanelOptionsMenuV from '@/components/panel-stack/controls/panel-options-menu.vue';
 import DropdownMenuV from '@/components/controls/dropdown-menu.vue';
-import MinimizeV from '@/components/controls/dropdown-menu.vue';
 
 import FullscreenNavV from '@/fixtures/mapnav/buttons/fullscreen-nav.vue';
 import HomeNavV from '@/fixtures/mapnav/buttons/home-nav.vue';

--- a/packages/ramp-core/src/fixtures/appbar/index.ts
+++ b/packages/ramp-core/src/fixtures/appbar/index.ts
@@ -19,16 +19,6 @@ class AppbarFixture extends AppbarAPI {
             (<any>this.$vApp.$i18n).mergeLocaleMessage(...value)
         );
 
-        this.$element.component('AppbarV', AppbarV);
-
-        // const appbarInstance = this.extend(AppbarV, {
-        //     iApi: this.$iApi,
-        //     store: this.$vApp.$store,
-        //     i18n: <any>this.$vApp.$i18n
-        // });
-        // const wrapper = document.createElement('div');
-        // appbarInstance.mount(wrapper);
-
         const { vNode, destroy, el } = this.mount(AppbarV, { app: this.$element });
         const innerShell = this.$vApp.$el.getElementsByClassName('inner-shell')[0];
         innerShell.appendChild(el.childNodes[0]);

--- a/packages/ramp-core/src/fixtures/crosshairs/index.ts
+++ b/packages/ramp-core/src/fixtures/crosshairs/index.ts
@@ -6,14 +6,6 @@ class CrosshairsFixture extends FixtureInstance {
     added(): void {
         console.log(`[fixture] ${this.id} added`);
 
-        this.$element.component('CrosshairsV', CrosshairsV);
-
-        // const crosshairsInstance = this.extend(CrosshairsV, {
-        //     iApi: this.$iApi
-        // });
-        // const wrapper = document.createElement('div');
-        // crosshairsInstance.mount(wrapper);
-
         const { vNode, destroy, el } = this.mount(CrosshairsV, { app: this.$element });
         const innerShell = this.$vApp.$el.getElementsByClassName('inner-shell')[0];
         innerShell.appendChild(el.childNodes[0]);

--- a/packages/ramp-core/src/fixtures/mapnav/index.ts
+++ b/packages/ramp-core/src/fixtures/mapnav/index.ts
@@ -17,19 +17,6 @@ class MapnavFixture extends MapnavAPI {
             (<any>this.$vApp.$i18n).mergeLocaleMessage(...value)
         );
 
-        this.$element.component('MapnavV', MapnavV);
-
-        // const wrapper = document.createElement('div');
-        // const mapnavInstance = this.extend(
-        //     MapnavV,
-        //     {
-        //         iApi: this.$iApi,
-        //         store: this.$vApp.$store,
-        //         i18n: <any>this.$vApp.$i18n
-        //     };
-        // );
-        // mapnavInstance.mount(wrapper);
-
         const { vNode, destroy, el } = this.mount(MapnavV, { app: this.$element });
         const innerShell = this.$vApp.$el.getElementsByClassName('inner-shell')[0];
         innerShell.appendChild(el.childNodes[0]);

--- a/packages/ramp-core/src/fixtures/northarrow/index.ts
+++ b/packages/ramp-core/src/fixtures/northarrow/index.ts
@@ -14,16 +14,6 @@ class NortharrowFixture extends NortharrowAPI {
             (value: NortharrowConfig | undefined) => this._parseConfig(value)
         );
 
-        this.$element.component('NortharrowV', NortharrowV);
-
-        // const wrapper = document.createElement('div');
-        // const northarrowInstance = this.extend(NortharrowV, {
-        //     iApi: this.$iApi,
-        //     store: this.$vApp.$store,
-        //     i18n: <any>this.$vApp.$i18n
-        // });
-        // northarrowInstance.mount(wrapper);
-
         const { vNode, destroy, el } = this.mount(NortharrowV, { app: this.$element });
         const innerShell = this.$vApp.$el.getElementsByClassName('inner-shell')[0];
         innerShell.appendChild(el.childNodes[0]);

--- a/packages/ramp-core/src/fixtures/overviewmap/index.ts
+++ b/packages/ramp-core/src/fixtures/overviewmap/index.ts
@@ -18,6 +18,10 @@ class OverviewmapFixture extends OverviewmapAPI {
             () => this.config,
             (value: OverviewmapConfig | undefined) => this._parseConfig(value)
         );
+
+        const { vNode, destroy, el } = this.mount(OverviewmapV, { app: this.$element });
+        const innerShell = this.$vApp.$el.getElementsByClassName('inner-shell')[0];
+        innerShell.appendChild(el.childNodes[0]);
     }
 
     removed() {

--- a/packages/ramp-core/src/fixtures/panguard/index.ts
+++ b/packages/ramp-core/src/fixtures/panguard/index.ts
@@ -10,16 +10,6 @@ class PanguardFixture extends FixtureInstance {
             (<any>this.$vApp.$i18n).mergeLocaleMessage(...value)
         );
 
-        this.$element.component('PanguardV', PanguardV);
-
-        // const panguardInstance = this.extend(PanguardV, {
-        //     iApi: this.$iApi,
-        //     store: this.$vApp.$store,
-        //     i18n: <any>this.$vApp.$i18n
-        // });
-        // const wrapper = document.createElement('div');
-        // panguardInstance.mount(wrapper);
-
         const { vNode, destroy, el } = this.mount(PanguardV, { app: this.$element });
         const innerShell = this.$vApp.$el.getElementsByClassName('inner-shell')[0];
         innerShell.appendChild(el.childNodes[0]);

--- a/packages/ramp-core/src/fixtures/scrollguard/index.ts
+++ b/packages/ramp-core/src/fixtures/scrollguard/index.ts
@@ -10,16 +10,6 @@ class ScrollguardFixture extends FixtureInstance {
             (<any>this.$vApp.$i18n).mergeLocaleMessage(...value)
         );
 
-        this.$element.component('ScrollguardV', ScrollguardV);
-
-        // const scrollguardInstance = this.extend(ScrollguardV, {
-        //     iApi: this.$iApi,
-        //     store: this.$vApp.$store,
-        //     i18n: <any>this.$vApp.$i18n
-        // });
-        // const wrapper = document.createElement('div');
-        // scrollguardInstance.mount(wrapper);
-
         const { vNode, destroy, el } = this.mount(ScrollguardV, { app: this.$element });
         const innerShell = this.$vApp.$el.getElementsByClassName('inner-shell')[0];
         innerShell.appendChild(el.childNodes[0]);


### PR DESCRIPTION
**Changes in this PR**
- Minimize button component is now registered to the correct component
- Removed commented out code and unnecessary component registration in dynamic fixtures
- I accidentally removed the overview map registration when rebasing, should be fixed now.

**Concerns**
None

**Testing this PR**
You can find a demo for this PR [here](http://ramp4-app.azureedge.net/demo/users/RyanCoulsonCA/vue3-fix-minimize/host/index.html).

To test, you can open any panels that contain a minimize button (details panel, settings, metadata, etc.) and make sure that the component is displayed correctly.