### PR TITLE
Fix mouse coords not showing up in web mercator format

### DIFF
--- a/packages/ramp-core/src/components/map/map-caption.vue
+++ b/packages/ramp-core/src/components/map/map-caption.vue
@@ -102,9 +102,9 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue';
+import { defineComponent, PropType } from 'vue';
 import { get } from '@/store/pathify-helper';
-import { GlobalEvents } from '@/api';
+import { Attribution, MouseCoords, RampMapConfig, ScaleBar } from '@/geo/api';
 import { MapCaptionStore } from '@/store/modules/map-caption';
 import { ConfigStore } from '@/store/modules/config';
 import NotificationsCaptionButtonV from '@/components/notification-center/caption-button.vue';
@@ -124,22 +124,13 @@ export default defineComponent({
         'notifications-caption-button': NotificationsCaptionButtonV
     },
 
-    mounted() {
-        // When map is created update scale
-
-        // TODO consider giving this handler a specific name and put in the document.
-        //      since it happens at map create, could be risky/tricky putting it in the "default" events
-        //      as odds are if there is any delay, the handler will miss the MAP_CREATED event.
-        //      But having a specific name means someone can remove it later at their lesiure.
-
-        // TODO consider what happens when a map is re-created. We might need to check if common handlers pre-exist.
-        //      or do some type of "one time only" boolean so we don't have double-handlers each time a projection changes.
-        //      we also need to be careful of the scenario where someone removes these default handlers after the map loads;
-        //      we would not want to re-add them back during a projection change -- want to respect the new custom handlers.
-
-        this.$iApi.event.on(GlobalEvents.MAP_CREATED, () => {
-            this.$iApi.geo.map.caption.updateScale();
-        });
+    watch: {
+        mapConfig(newConfig: RampMapConfig, oldConfig: RampMapConfig) {
+            if (newConfig === oldConfig) {
+                return;
+            }
+            this.$iApi.geo.map.caption.createCaption(this.mapConfig.caption);
+        }
     },
 
     updated() {
@@ -161,7 +152,8 @@ export default defineComponent({
          * Toggle the scale units
          */
         onScaleClick() {
-            this.$iApi.$vApp.$store.set(MapCaptionStore.toggleScale, {});
+            // undefined argument will toggle the scale unit
+            this.$iApi.$vApp.$store.set(MapCaptionStore.toggleScale, undefined);
             this.$iApi.geo.map.caption.updateScale();
         }
     }

--- a/packages/ramp-core/src/geo/map/caption.ts
+++ b/packages/ramp-core/src/geo/map/caption.ts
@@ -45,8 +45,7 @@ export class MapCaptionAPI extends APIScope {
             });
         } else {
             // get formatter specified in the config
-            const defaultFormatter: string | undefined =
-                captionConfig.mouseCoords.formatter;
+            const defaultFormatter: string | undefined = captionConfig.mouseCoords.formatter;
             if (defaultFormatter !== undefined) {
                 this.setPointFormatter(defaultFormatter);
             }
@@ -59,14 +58,10 @@ export class MapCaptionAPI extends APIScope {
             });
         } else {
             // get the scalebar unit specified in the config
-            const useImperialUnits: boolean | undefined =
-                captionConfig.scaleBar.imperialScale;
+            const useImperialUnits: boolean | undefined = captionConfig.scaleBar.imperialScale;
             if (useImperialUnits !== undefined) {
                 // update the value in the store
-                this.$iApi.$vApp.$store.set(
-                    MapCaptionStore.toggleScale,
-                    useImperialUnits
-                );
+                this.$iApi.$vApp.$store.set(MapCaptionStore.toggleScale, useImperialUnits);
                 // wait for the map to load since updateScale needs map view resolution
                 this.$iApi.geo.map.viewPromise.then(() => {
                     this.updateScale();
@@ -173,17 +168,16 @@ export class MapCaptionAPI extends APIScope {
      * @function updateScale
      */
     updateScale(): void {
-        const currentScaleBar:
-            | ScaleBar
-            | undefined = this.$iApi.$vApp.$store.get(MapCaptionStore.scale);
+        const currentScaleBar: ScaleBar | undefined = this.$iApi.$vApp.$store.get(
+            MapCaptionStore.scale
+        );
 
         // if the current scale bar is disabled, then do not update it
         if (currentScaleBar?.disabled) {
             return;
         }
 
-        const isImperialScale: boolean =
-            currentScaleBar?.isImperialScale || false;
+        const isImperialScale: boolean = currentScaleBar?.isImperialScale || false;
 
         // the starting length of the scale line in pixels
         // reduce the length of the bar on extra small layouts

--- a/packages/ramp-core/src/store/modules/map-caption/map-caption-store.ts
+++ b/packages/ramp-core/src/store/modules/map-caption/map-caption-store.ts
@@ -13,10 +13,7 @@ const actions = {
     setAttribution: (context: MapCaptionContext, attribution: Attribution) => {
         context.commit('SET_ATTRIBUTION', attribution);
     },
-    setCursorCoords: (
-        context: MapCaptionContext,
-        cursorCoords: MouseCoords
-    ) => {
+    setCursorCoords: (context: MapCaptionContext, cursorCoords: MouseCoords) => {
         context.commit('SET_CURSOR_COORDS', cursorCoords);
     },
     setScale: (context: MapCaptionContext, scale: ScaleBar) => {


### PR DESCRIPTION
[Demo](http://ramp4-app.azureedge.net/demo/users/yileifeng/vue3-mercator-coords/host/index.html)

**Changes**:
- added in some missed changes from this [PR](https://github.com/ramp4-pcar4/ramp4-pcar4/pull/667) for mouse coords to display using the correct mercator formatting

**Testing**:
Mouse coords display using `WEB_MERCATOR` format